### PR TITLE
Fix ESP and Player Glow F1 toggle and synchronization

### DIFF
--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -536,14 +536,14 @@ static void set_vars(uint64_t add_addr)
 	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 14, bone_addr);
 	uint64_t thirdperson_addr = 0;
 	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 15, thirdperson_addr);
-	uint64_t shooting_addr = 0;
-	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 16, shooting_addr);
-	uint64_t chargerifle_addr = 0;
-	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 17, chargerifle_addr);
 	uint64_t spectators_addr = 0;
-	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 18, spectators_addr);
+	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 16, spectators_addr);
 	uint64_t allied_spectators_addr = 0;
-	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 19, allied_spectators_addr);
+	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 17, allied_spectators_addr);
+	uint64_t chargerifle_addr = 0;
+	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 18, chargerifle_addr);
+	uint64_t shooting_addr = 0;
+	client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 19, shooting_addr);
 
 	uint32_t check = 0;
 	client_mem.Read<uint32_t>(check_addr, check);

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -47,6 +47,7 @@ bool next = false; //read write
 
 uint64_t add[20];
 
+bool k_f1 = 0;
 bool k_f5 = 0;
 bool k_f6 = 0;
 bool k_f8 = 0;
@@ -172,6 +173,17 @@ int main(int argc, char** argv)
 		if (IsKeyDown(VK_F4))
 		{
 			active = false;
+		}
+
+		if (IsKeyDown(VK_F1) && k_f1 == 0)
+		{
+			k_f1 = 1;
+			esp = !esp;
+			player_glow = esp;
+		}
+		else if (!IsKeyDown(VK_F1) && k_f1 == 1)
+		{
+			k_f1 = 0;
 		}
 
 		if (IsKeyDown(VK_F5) && k_f5 == 0)


### PR DESCRIPTION
This PR fixes an issue where ESP and Glow would spontaneously turn off. The root cause was a synchronization mismatch in the memory address array between the host (apex_dma) and the guest (apex_guest), which caused the host to overwrite the 'valid' flag when spectators were present. Additionally, a new F1 master toggle has been added to the guest client to control both ESP and Player Glow simultaneously, with a proper toggle mechanism to ensure stability.

---
*PR created automatically by Jules for task [1003435015405926357](https://jules.google.com/task/1003435015405926357) started by @albatror*