### PR TITLE
Refactor DDS and Aimbot Stickiness

### DIFF
--- a/apex_dma/Game.h
+++ b/apex_dma/Game.h
@@ -157,6 +157,6 @@ Entity getEntity(uintptr_t ptr);
 //Item getItem(uintptr_t ptr);
 bool WorldToScreen(Vector from, float* m_vMatrix, int targetWidth, int targetHeight, Vector& to);
 float CalculateFov(Entity& from, Entity& target);
-QAngle CalculateBestBoneAim(Entity& from, uintptr_t target, float max_fov);
+QAngle CalculateBestBoneAim(Entity& from, uintptr_t target, float max_fov, float smoothing);
 void get_class_name(uint64_t entity_ptr, char* out_str);
 void charge_rifle_hack(uint64_t entity_ptr);

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -252,13 +252,11 @@ void ProcessPlayer(Entity &LPlayer, Entity &target, uint64_t entitylist, int ind
 		is_aimentity_visible = visible;
 	}
 
-	if (shooting && aimentity != 0)
+	if (aimentity != 0 && lock)
 	{
-		lastvis_aim[index] = target.lastVisTime();
-		return;
+		// Stick to target
 	}
-
-	if(aim==2)
+	else if (aim == 2)
 	{
 		if (visible && fov <= max_fov)
 		{
@@ -270,7 +268,7 @@ void ProcessPlayer(Entity &LPlayer, Entity &target, uint64_t entitylist, int ind
 		}
 		else
 		{
-			if(aimentity == target.ptr && !shooting)
+			if (aimentity == target.ptr && !shooting)
 			{
 				aimentity = tmp_aimentity = lastaimentity = 0;
 			}


### PR DESCRIPTION
This PR refactors the distance-dependent smoothing (DDS) logic and enhances the aimbot's target stickiness. 

Key changes include:
1. **Guest Client (main.cpp):**
   - DDS parameters (max_fov, smooth) are now calculated once per frame based on the "best" player (closest to crosshair), avoiding the "last player in loop wins" bug.
   - Implemented a `dds_active` flag that disables the aimbot's response to `VK_RBUTTON` if the target is beyond the DDS range (70m), while allowing `VK_LBUTTON` to always trigger it.
   - Added stickiness for the DDS-selected player to ensure consistent settings while aiming.

2. **Host Component (apex_dma.cpp):**
   - Modified `ProcessPlayer` to skip target acquisition logic if a target is already locked (`lock == true`). This guarantees that the aimbot will never switch to another target as long as the current one is valid.
   - Fixed an issue where entity processing (including Glow) was completely skipped while shooting.

3. **General Improvements:**
   - Fixed a compilation error caused by a signature mismatch for `CalculateBestBoneAim`.
   - Improved overall code cleanliness and robustness of host-guest synchronization.

---
*PR created automatically by Jules for task [15748703851901347781](https://jules.google.com/task/15748703851901347781) started by @albatror*