### PR TITLE
Add Background Window and Header Line to Spectator List

### DIFF
--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -200,7 +200,8 @@ void Overlay::RenderSpectator() {
 	if (!v.spectator_notifier) return;
 	ImGui::SetNextWindowPos(ImVec2(490, 0));
 	ImGui::SetNextWindowSize(ImVec2(190, 130));
-	ImGui::Begin(XorStr("##spectator_list"), nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoBackground);
+	ImGui::Begin(XorStr("##spectator_list"), nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar);
+	DrawLine(ImVec2(491, 2), ImVec2(679, 2), RED, 2);
 	ImGui::TextColored(RED, "%d", spectators);
 	ImGui::SameLine();
 	ImGui::Text("-");

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -458,7 +458,7 @@ void Overlay::RenderInfo()
 	ImGui::SetNextWindowPos(ImVec2(300, 0));
 	ImGui::SetNextWindowSize(ImVec2(170, 100));
 	ImGui::Begin(XorStr("##info"), (bool*)true, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar);
-	DrawLine(ImVec2(1, 2), ImVec2(170, 2), RED, 2);;
+	DrawLine(ImVec2(301, 2), ImVec2(469, 2), RED, 2);
 	ImGui::Text(XorStr("DDS :"));
 	ImGui::SameLine();
 	ImGui::Text("%d meters", (int)(DDS / 40));


### PR DESCRIPTION
This change adds a black background window to the spectator list overlay in the `apex_guest` client, matching the style of the existing information window. It also adds a red header line to the top of the spectator list and fixes the positioning of the red line in the information window to ensure visual consistency across the UI. Both windows now properly respect absolute screen coordinates for their header lines.

---
*PR created automatically by Jules for task [14029835390769276934](https://jules.google.com/task/14029835390769276934) started by @albatror*