### PR TITLE
Hide info and spectator windows by default and add menu toggles

### DIFF
--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -529,6 +529,7 @@ int main(int argc, char** argv)
 				config >> v.line;
 				config >> v.skeleton;
 				config >> v.spectator_notifier;
+				config >> v.info_window;
 				config >> v.target_indicator;
 				config >> v.target_indicator_fov;
 				config >> glowr;

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -305,6 +305,8 @@ void Overlay::RenderMenu()
 			ImGui::Checkbox(XorStr("Skeleton"), &v.skeleton);
 			ImGui::SameLine();
 			ImGui::Checkbox(XorStr("Spectator list"), &v.spectator_notifier);
+			ImGui::SameLine();
+			ImGui::Checkbox(XorStr("Info window"), &v.info_window);
 			ImGui::Checkbox(XorStr("Target Indicator"), &v.target_indicator);
 			if (v.target_indicator) {
 				ImGui::SameLine();
@@ -355,6 +357,7 @@ void Overlay::RenderMenu()
 					config << v.line << "\n";
 					config << v.skeleton << "\n";
 					config << v.spectator_notifier << "\n";
+					config << v.info_window << "\n";
 					config << v.target_indicator << "\n";
 					config << v.target_indicator_fov << "\n";
 					config << glowr << "\n";
@@ -405,6 +408,7 @@ void Overlay::RenderMenu()
 					config >> v.line;
 					config >> v.skeleton;
 					config >> v.spectator_notifier;
+					config >> v.info_window;
 					config >> v.target_indicator;
 					config >> v.target_indicator_fov;
 					config >> glowr;
@@ -455,6 +459,7 @@ void Overlay::RenderMenu()
 
 void Overlay::RenderInfo()
 {
+	if (!v.info_window) return;
 	ImGui::SetNextWindowPos(ImVec2(300, 0));
 	ImGui::SetNextWindowSize(ImVec2(170, 100));
 	ImGui::Begin(XorStr("##info"), (bool*)true, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar);

--- a/apex_guest/Client/Client/overlay.h
+++ b/apex_guest/Client/Client/overlay.h
@@ -33,7 +33,8 @@ typedef struct visuals
 	bool shieldbar = true;
 	bool name = true;
 	bool skeleton = false;
-	bool spectator_notifier = true;
+	bool spectator_notifier = false;
+	bool info_window = false;
 	bool target_indicator = false;
 	float target_indicator_fov = 10.0f;
 }visuals;


### PR DESCRIPTION
The user wanted the overlay's "info window" (left) and "spectator list" (right) to be hidden by default, with options in the settings menu to toggle them.

Changes:
- Modified `visuals` struct in `overlay.h` to include `info_window` and set both `info_window` and `spectator_notifier` to `false` by default.
- Updated `Overlay::RenderInfo` in `overlay.cpp` to check `v.info_window` before rendering.
- Added a checkbox for "Info window" in the Visuals tab of the overlay menu.
- Updated `Settings.txt` persistence logic (Save/Load in `overlay.cpp` and startup load in `main.cpp`) to handle the new `info_window` setting.

---
*PR created automatically by Jules for task [2801044841909925870](https://jules.google.com/task/2801044841909925870) started by @albatror*