### PR TITLE
Re-activate 1v1 and dummy training via overlay menu

### DIFF
--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -550,7 +550,8 @@ int main(int argc, char** argv)
 				config >> glowcolorknocked[0];
 				config >> glowcolorknocked[1];
 				config >> glowcolorknocked[2];
-				//config >> std::boolalpha >> firing_range;
+				config >> std::boolalpha >> firing_range;
+				config >> std::boolalpha >> onevone;
 				config >> DDS;
 				config >> min_max_fov;
 				config >> max_max_fov;

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -21,6 +21,7 @@ extern int spectators;
 extern int allied_spectators;
 
 extern bool onevone;
+extern bool firing_range;
 
 extern bool flickbot;
 extern int flickbot_key;
@@ -242,6 +243,8 @@ void Overlay::RenderMenu()
 			ImGui::Checkbox(XorStr("Superglide"), &superglide);
 			ImGui::Checkbox(XorStr("BHop"), &bhop);
 			ImGui::Checkbox(XorStr("WallJump"), &walljump);
+			ImGui::Checkbox(XorStr("Firing Range"), &firing_range);
+			ImGui::Checkbox(XorStr("1v1"), &onevone);
 			ImGui::EndTabItem();
 		}
 		if (ImGui::BeginTabItem(XorStr("Config")))
@@ -378,7 +381,8 @@ void Overlay::RenderMenu()
 					config << glowcolorknocked[0] << "\n";
 					config << glowcolorknocked[1] << "\n";
 					config << glowcolorknocked[2] << "\n";
-					//config << std::boolalpha << firing_range << "\n";
+					config << std::boolalpha << firing_range << "\n";
+					config << std::boolalpha << onevone << "\n";
 					config << DDS << "\n";
 					config << min_max_fov << "\n";
 					config << max_max_fov << "\n";
@@ -386,6 +390,15 @@ void Overlay::RenderMenu()
 					config << max_smooth << "\n";
 					config << min_cfsize << "\n";
 					config << max_cfsize << "\n";
+					config << flickbot << "\n";
+					config << flickbot_key << "\n";
+					config << triggerbot << "\n";
+					config << triggerbot_key << "\n";
+					config << superglide << "\n";
+					config << bhop << "\n";
+					config << walljump << "\n";
+					config << flickbot_fov << "\n";
+					config << flickbot_smooth << "\n";
 					config.close();
 				}
 			}
@@ -429,7 +442,8 @@ void Overlay::RenderMenu()
 					config >> glowcolorknocked[0];
 					config >> glowcolorknocked[1];
 					config >> glowcolorknocked[2];
-					//config >> std::boolalpha >> firing_range;
+					config >> std::boolalpha >> firing_range;
+					config >> std::boolalpha >> onevone;
 					config >> DDS;
 					config >> min_max_fov;
 					config >> max_max_fov;


### PR DESCRIPTION
This change re-activates the 1v1 and dummy training (firing range) features by adding them to the overlay's "Misc" menu. Previously, these features might have been toggled by the F9 key, which is now used for memory dumping. By moving them to the menu, users can toggle them independently of hotkeys. The configuration system was also updated to ensure these settings, along with previously missing ones like flickbot and movement scripts, are correctly saved and loaded from `Settings.txt`.

---
*PR created automatically by Jules for task [13960509891558484803](https://jules.google.com/task/13960509891558484803) started by @albatror*