### PR TITLE
Add visible FOV circles for Flickbot and Triggerbot

### DIFF
--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -68,6 +68,7 @@ float flickbot_smooth = 20.0f;
 bool triggerbot = false;
 int triggerbot_key = 0;
 bool triggerbot_aiming = false;
+float triggerbot_fov = 10.0f;
 
 bool superglide = false;
 bool bhop = false;
@@ -985,14 +986,16 @@ static void AimbotLoop()
 			// Triggerbot logic
 			if (triggerbot && triggerbot_aiming && aimentity != 0) {
 				Entity Target = getEntity(aimentity);
-				float aimed_at_time = 0;
-				apex_mem.Read<float>(Target.ptr + OFFSET_LAST_AIMEDAT_TIME, aimed_at_time);
-				if (aimed_at_time > last_aimed_at_time_tb) {
-					apex_mem.Write<int>(g_Base + OFFSET_IN_ATTACK + 0x8, 5);
-					std::this_thread::sleep_for(std::chrono::milliseconds(20));
-					apex_mem.Write<int>(g_Base + OFFSET_IN_ATTACK + 0x8, 4);
+				if (CalculateFov(LPlayer, Target) <= triggerbot_fov) {
+					float aimed_at_time = 0;
+					apex_mem.Read<float>(Target.ptr + OFFSET_LAST_AIMEDAT_TIME, aimed_at_time);
+					if (aimed_at_time > last_aimed_at_time_tb) {
+						apex_mem.Write<int>(g_Base + OFFSET_IN_ATTACK + 0x8, 5);
+						std::this_thread::sleep_for(std::chrono::milliseconds(20));
+						apex_mem.Write<int>(g_Base + OFFSET_IN_ATTACK + 0x8, 4);
+					}
+					last_aimed_at_time_tb = aimed_at_time;
 				}
-				last_aimed_at_time_tb = aimed_at_time;
 			}
 
 			// Flickbot logic
@@ -1439,6 +1442,10 @@ while (vars_t)
         uint64_t flickbot_smooth_addr = 0;
         client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 45, flickbot_smooth_addr);
         if (flickbot_smooth_addr) client_mem.Read<float>(flickbot_smooth_addr, flickbot_smooth);
+
+        uint64_t triggerbot_fov_addr = 0;
+        client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 46, triggerbot_fov_addr);
+        if (triggerbot_fov_addr) client_mem.Read<float>(triggerbot_fov_addr, triggerbot_fov);
 
         if (esp && next)
         {

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -50,6 +50,7 @@ float flickbot_smooth = 20.0f;
 bool triggerbot = false;
 int triggerbot_key = 0x06;
 bool triggerbot_aiming = false;
+float triggerbot_fov = 10.0f;
 
 bool superglide = false;
 bool bhop = false;
@@ -160,7 +161,7 @@ bool next = false; //read write
 
 int index = 0;
 
-uint64_t add[46];//46
+uint64_t add[47];//47
 
 bool k_f1 = 0;
 bool k_f2 = 0;
@@ -472,6 +473,7 @@ int main(int argc, char** argv)
 	add[43] = (uintptr_t)&SuperKey;
 	add[44] = (uintptr_t)&flickbot_fov;
 	add[45] = (uintptr_t)&flickbot_smooth;
+	add[46] = (uintptr_t)&triggerbot_fov;
 
 	printf(XorStr("add offset: 0x%I64x\n"), (uint64_t)&add[0] - (uint64_t)GetModuleHandle(NULL));
 
@@ -567,6 +569,9 @@ int main(int argc, char** argv)
 				config >> walljump;
 				config >> flickbot_fov;
 				config >> flickbot_smooth;
+				config >> triggerbot_fov;
+				config >> v.flickbot_fov_circle;
+				config >> v.triggerbot_fov_circle;
 				config.close();
 			}
 		}

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -29,6 +29,7 @@ extern float flickbot_smooth;
 
 extern bool triggerbot;
 extern int triggerbot_key;
+extern float triggerbot_fov;
 
 extern bool superglide;
 extern bool bhop;
@@ -234,6 +235,7 @@ void Overlay::RenderMenu()
 					}
 				}
 			}
+			ImGui::SliderFloat(XorStr("Trigger FOV"), &triggerbot_fov, 1.0f, 1000.0f, "%.2f");
 
 			ImGui::EndTabItem();
 		}
@@ -312,6 +314,8 @@ void Overlay::RenderMenu()
 				ImGui::SameLine();
 				ImGui::SliderFloat(XorStr("Indicator FOV"), &v.target_indicator_fov, 1.0f, 1000.0f, "%.2f");
 			}
+			ImGui::Checkbox(XorStr("Flickbot Circle fov"), &v.flickbot_fov_circle);
+			ImGui::Checkbox(XorStr("Triggerbot Circle fov"), &v.triggerbot_fov_circle);
 			//test glow
 			ImGui::Dummy(ImVec2(0.0f, 10.0f));
 			ImGui::Text(XorStr("Player Glow Visable:"));
@@ -386,6 +390,18 @@ void Overlay::RenderMenu()
 					config << max_smooth << "\n";
 					config << min_cfsize << "\n";
 					config << max_cfsize << "\n";
+					config << flickbot << "\n";
+					config << flickbot_key << "\n";
+					config << triggerbot << "\n";
+					config << triggerbot_key << "\n";
+					config << superglide << "\n";
+					config << bhop << "\n";
+					config << walljump << "\n";
+					config << flickbot_fov << "\n";
+					config << flickbot_smooth << "\n";
+					config << triggerbot_fov << "\n";
+					config << v.flickbot_fov_circle << "\n";
+					config << v.triggerbot_fov_circle << "\n";
 					config.close();
 				}
 			}
@@ -446,6 +462,9 @@ void Overlay::RenderMenu()
 					config >> walljump;
 					config >> flickbot_fov;
 					config >> flickbot_smooth;
+					config >> triggerbot_fov;
+					config >> v.flickbot_fov_circle;
+					config >> v.triggerbot_fov_circle;
 					config.close();
 				}
 			}
@@ -650,6 +669,20 @@ DWORD Overlay::CreateOverlay()
 			ImGui::Begin("##circlefov", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar);
 			auto draw = ImGui::GetBackgroundDrawList();
 			draw->AddCircle(ImVec2(getWidth() / 2, getHeight() / 2), cfsize, IM_COL32(255, 0, 0, 255), 100, 1.0f);
+			ImGui::End();
+		}
+		if (v.flickbot_fov_circle)
+		{
+			ImGui::Begin("##flickcirclefov", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar);
+			auto draw = ImGui::GetBackgroundDrawList();
+			draw->AddCircle(ImVec2(getWidth() / 2, getHeight() / 2), flickbot_fov, IM_COL32(0, 0, 255, 255), 100, 1.0f);
+			ImGui::End();
+		}
+		if (v.triggerbot_fov_circle)
+		{
+			ImGui::Begin("##triggercirclefov", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoScrollbar);
+			auto draw = ImGui::GetBackgroundDrawList();
+			draw->AddCircle(ImVec2(getWidth() / 2, getHeight() / 2), triggerbot_fov, IM_COL32(255, 165, 0, 255), 100, 1.0f);
 			ImGui::End();
 		}
 		RenderEsp();

--- a/apex_guest/Client/Client/overlay.h
+++ b/apex_guest/Client/Client/overlay.h
@@ -37,6 +37,8 @@ typedef struct visuals
 	bool info_window = false;
 	bool target_indicator = false;
 	float target_indicator_fov = 10.0f;
+	bool flickbot_fov_circle = false;
+	bool triggerbot_fov_circle = false;
 }visuals;
 
 struct GColor {


### PR DESCRIPTION
This change adds a visible FOV circle for both Flickbot and Triggerbot to the overlay, allowing users to visualize the activation area for these features. 

Key changes:
1. **Client Overlay**: Added checkboxes for 'Flickbot Circle fov' and 'Triggerbot Circle fov' in the Visuals tab.
2. **Triggerbot FOV**: Introduced a dedicated 'Trigger FOV' slider and synchronized the value with the host component.
3. **Rendering**: Implemented drawing of a blue circle for Flickbot and an orange circle for Triggerbot at the center of the screen.
4. **Persistence**: Fixed a bug where Flickbot and Triggerbot settings were loaded but not saved, and added the new FOV settings to the `Settings.txt` serialization logic.
5. **Host Logic**: Updated the Triggerbot implementation in `apex_dma` to only fire if the target is within the specified FOV.

---
*PR created automatically by Jules for task [17162190500909480076](https://jules.google.com/task/17162190500909480076) started by @albatror*