### PR TITLE
Fix Player Glow Persistence and Logic Bugs

### DIFF
--- a/apex_dma/Game.cpp
+++ b/apex_dma/Game.cpp
@@ -1,4 +1,5 @@
 #include <array>
+#include <cfloat>
 #include "prediction.h"
 #include <cassert>
 #include <ostream>
@@ -289,7 +290,8 @@ float Entity::GetYaw()
 
 bool Entity::isGlowing()
 {
-	return *(int*)(buffer + OFFSET_GLOW_ENABLE) == 7;
+	int glow = *(int*)(buffer + OFFSET_GLOW_ENABLE);
+	return (glow >= 5 && glow <= 7);
 }
 
 bool Entity::isZooming()
@@ -313,9 +315,6 @@ bool Entity::isZooming()
 
     void Entity::enableGlow()
     {
-
-		//static const int contextId = 0;
-		//int settingIndex = 50;
 		std::array<unsigned char, 4> highlightFunctionBits = {
 			insidevalue,   // InsideFunction
 			outsidevalue, // OutlineFunction: HIGHLIGHT_OUTLINE_OBJECTIVE
@@ -324,27 +323,23 @@ bool Entity::isZooming()
 		};
 
 		apex_mem.Write<int>(ptr + OFFSET_GLOW_ENABLE, contextId);
-		long highlightSettingsPtr;
-		apex_mem.Read<long>(g_Base + HIGHLIGHT_SETTINGS, highlightSettingsPtr);
+		apex_mem.Write<int>(ptr + OFFSET_HIGHLIGHTSERVERACTIVESTATES, 1);
 		apex_mem.Write<int>(ptr + OFFSET_GLOW_THROUGH_WALLS, 2);
-		apex_mem.Write<typeof(highlightFunctionBits)>(highlightSettingsPtr + HIGHLIGHT_TYPE_SIZE * contextId + 0x0, highlightFunctionBits);
-		apex_mem.Write<typeof(highlightParameter)>(highlightSettingsPtr + HIGHLIGHT_TYPE_SIZE * contextId + 0x4, highlightParameter);
-		//apex_mem.Write<float>(ptr + 0x264, 8.0E+4);
-
-		//apex_mem.Write(g_Base + OFFSET_GLOW_FIX, 1);
 		apex_mem.Write<float>(ptr + GLOW_DISTANCE, 88888);
+		apex_mem.Write<float>(ptr + GLOW_LIFE_TIME, FLT_MAX);
 
-
-
+		long highlightSettingsPtr;
+		if (apex_mem.Read<long>(g_Base + HIGHLIGHT_SETTINGS, highlightSettingsPtr) && highlightSettingsPtr != 0) {
+			apex_mem.Write<typeof(highlightFunctionBits)>(highlightSettingsPtr + HIGHLIGHT_TYPE_SIZE * contextId + 0x0, highlightFunctionBits);
+			apex_mem.Write<typeof(highlightParameter)>(highlightSettingsPtr + HIGHLIGHT_TYPE_SIZE * contextId + 0x4, highlightParameter);
+		}
     }
 ///////////////////////////
 
 void Entity::disableGlow()
 {
-	//apex_mem.Write<int>(ptr + OFFSET_GLOW_T1, 0);
-	//apex_mem.Write<int>(ptr + OFFSET_GLOW_T2, 0);
-	//apex_mem.Write<int>(ptr + OFFSET_GLOW_ENABLE, 2);
-	//apex_mem.Write<int>(ptr + OFFSET_GLOW_THROUGH_WALLS, 5);
+	apex_mem.Write<int>(ptr + OFFSET_GLOW_ENABLE, 0);
+	apex_mem.Write<int>(ptr + OFFSET_GLOW_THROUGH_WALLS, 0);
 }
 
 void Entity::SetViewAngles(SVector angles)

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -179,11 +179,9 @@ std::array<float, 3> highlightParameter;
 // Inside SetPlayerGlow function
 void SetPlayerGlow(Entity& LPlayer, Entity& Target, int index)
 {
-    	if (player_glow >= 1)
+	if (player_glow)
     	{
-    			if (!Target.isGlowing() || (int)Target.buffer[OFFSET_GLOW_THROUGH_WALLS_GLOW_VISIBLE_TYPE] != 1) {
-    				float currentEntityTime = 5000.f;
-    				if (!isnan(currentEntityTime) && currentEntityTime > 0.f) {
+			if (!Target.isGlowing() || (int)Target.buffer[OFFSET_GLOW_THROUGH_WALLS] != 2) {
     					if (!(firing_range) && (Target.isKnocked() || !Target.isAlive()))
     					{
     						contextId = 5;
@@ -203,11 +201,9 @@ void SetPlayerGlow(Entity& LPlayer, Entity& Target, int index)
     						highlightParameter = { glowr, glowg, glowb };
     					}
     					Target.enableGlow();
-    				}
     			}
     	}
-    	//////////////////////////////////////////////////////////////////////////////////////////////////
-		else if((player_glow == 0) && Target.isGlowing())
+		else if(Target.isGlowing())
 		{
 			Target.disableGlow();
 		}
@@ -644,20 +640,9 @@ if (bhop && SuperKey) {
 					
 					ProcessPlayer(LPlayer, Target, entitylist, i, spectated_ptr);
 
-					int entity_team = Target.getTeamId();
-					if (entity_team == team_player && !onevone)
+					if (!player_glow && Target.isGlowing())
 					{
-						continue;
-					}
-
-					if (player_glow && !Target.isGlowing())
-					{
-						Target.enableGlow();
-					}
-					else if (!player_glow && Target.isGlowing())
-					{
-						Target.enableGlow();
-						//Target.disableGlow();
+						Target.disableGlow();
 					}
 				}
 			}

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -180,33 +180,36 @@ std::array<float, 3> highlightParameter;
 void SetPlayerGlow(Entity& LPlayer, Entity& Target, int index)
 {
 	if (player_glow)
-    	{
-			if (!Target.isGlowing() || (int)Target.buffer[OFFSET_GLOW_THROUGH_WALLS] != 2) {
-    					if (!(firing_range) && (Target.isKnocked() || !Target.isAlive()))
-    					{
-    						contextId = 5;
-    						settingIndex = 80;
-    						highlightParameter = { glowrknocked, glowgknocked, glowbknocked };
-    					}
-    					else if (Target.lastVisTime() > lastvis_aim[index] || (Target.lastVisTime() < 0.f && lastvis_aim[index] > 0.f))
-    					{
-    						contextId = 6;
-    						settingIndex = 81;
-    						highlightParameter = { glowrviz, glowgviz, glowbviz };
-    					}
-    					else 
-    					{
-    						contextId = 7;
-    						settingIndex = 82;
-    						highlightParameter = { glowr, glowg, glowb };
-    					}
-    					Target.enableGlow();
-    			}
-    	}
-		else if(Target.isGlowing())
+	{
+		int newContextId;
+		if (!(firing_range) && (Target.isKnocked() || !Target.isAlive()))
 		{
-			Target.disableGlow();
+			newContextId = 5;
+			highlightParameter = { glowrknocked, glowgknocked, glowbknocked };
 		}
+		else if (Target.lastVisTime() > lastvis_aim[index] || (Target.lastVisTime() < 0.f && lastvis_aim[index] > 0.f))
+		{
+			newContextId = 6;
+			highlightParameter = { glowrviz, glowgviz, glowbviz };
+		}
+		else
+		{
+			newContextId = 7;
+			highlightParameter = { glowr, glowg, glowb };
+		}
+
+		int currentContextId = *(int*)(Target.buffer + OFFSET_GLOW_ENABLE);
+		int currentVisType = *(int*)(Target.buffer + OFFSET_GLOW_THROUGH_WALLS);
+
+		if (currentContextId != newContextId || currentVisType != 2) {
+			contextId = newContextId;
+			Target.enableGlow();
+		}
+	}
+	else if(Target.isGlowing())
+	{
+		Target.disableGlow();
+	}
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
The user reported that player glow worked initially but disappeared after a short time, and worked normally when spectating. 

I identified several issues:
1. The glow life time was not being set, allowing the game to clear it.
2. The server active state flag was not being set to force the client to show the glow.
3. The isGlowing check only recognized ID 7, causing constant re-enabling for visible players (ID 6).
4. A typo in the main loop called enableGlow even when the feature was disabled.
5. Redundant logic in the main loop was using global state that could be stale or overwritten by other players in the loop.

This PR fixes these issues by enhancing the memory write logic and cleaning up the orchestration in the host component.

---
*PR created automatically by Jules for task [7190123815525874829](https://jules.google.com/task/7190123815525874829) started by @albatror*