### PR TITLE
Add Lock Target feature

### DIFF
--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -36,6 +36,7 @@ bool skeleton = false;
 //bool item_glow = false;
 bool player_glow = false;
 bool aim_no_recoil = true;
+bool lock_target = false;
 bool aiming = false;
 
 extern float smooth;
@@ -1114,7 +1115,11 @@ static void AimbotLoop()
 					continue;
 				}
 
-				lock = true;
+				if (lock_target)
+					lock = true;
+				else
+					lock = false;
+
 				lastaimentity = aimentity;
 
 				if (aimentity != last_locked_entity) {
@@ -1499,6 +1504,10 @@ while (vars_t)
         uint64_t walljump_addr = 0;
         client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 42, walljump_addr);
         if (walljump_addr) client_mem.Read<bool>(walljump_addr, walljump);
+
+        uint64_t lock_target_addr = 0;
+        client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 47, lock_target_addr);
+        if (lock_target_addr) client_mem.Read<bool>(lock_target_addr, lock_target);
 
         uint64_t superkey_addr = 0;
         client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 43, superkey_addr);

--- a/apex_guest/Client/Client/config.cpp
+++ b/apex_guest/Client/Client/config.cpp
@@ -14,6 +14,7 @@ extern int aim;
 extern bool esp;
 extern bool player_glow;
 extern bool aim_no_recoil;
+extern bool lock_target;
 extern float max_dist;
 extern float default_smooth;
 extern float default_fov;
@@ -70,6 +71,7 @@ void SaveConfig(const std::string& filename) {
     file << "esp " << std::boolalpha << esp << "\n";
     file << "player_glow " << std::boolalpha << player_glow << "\n";
     file << "aim_no_recoil " << std::boolalpha << aim_no_recoil << "\n";
+    file << "lock_target " << std::boolalpha << lock_target << "\n";
     file << "max_dist " << max_dist << "\n";
     file << "default_smooth " << default_smooth << "\n";
     file << "default_fov " << default_fov << "\n";
@@ -135,6 +137,7 @@ void LoadConfig(const std::string& filename) {
         else if (key == "esp") ss >> std::boolalpha >> esp;
         else if (key == "player_glow") ss >> std::boolalpha >> player_glow;
         else if (key == "aim_no_recoil") ss >> std::boolalpha >> aim_no_recoil;
+        else if (key == "lock_target") ss >> std::boolalpha >> lock_target;
         else if (key == "max_dist") ss >> max_dist;
         else if (key == "default_smooth") ss >> default_smooth;
         else if (key == "default_fov") ss >> default_fov;

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -67,6 +67,7 @@ bool esp = false; //read
 //bool item_glow = false;
 bool player_glow = false;
 bool aim_no_recoil = true;
+bool lock_target = false;
 bool aiming = false; //read
 uint64_t g_Base = 0; //write
 float max_dist = 120.0f * 40.0f;
@@ -162,7 +163,7 @@ bool next = false; //read write
 
 int index = 0;
 
-uint64_t add[47];//47
+uint64_t add[48];//48
 
 bool k_f1 = 0;
 bool k_f2 = 0;
@@ -475,6 +476,7 @@ int main(int argc, char** argv)
 	add[44] = (uintptr_t)&flickbot_fov;
 	add[45] = (uintptr_t)&flickbot_smooth;
 	add[46] = (uintptr_t)&triggerbot_fov;
+	add[47] = (uintptr_t)&lock_target;
 
 	printf(XorStr("add offset: 0x%I64x\n"), (uint64_t)&add[0] - (uint64_t)GetModuleHandle(NULL));
 

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -10,6 +10,7 @@ extern bool esp;
 //extern bool item_glow;
 extern bool player_glow;
 extern bool aim_no_recoil;
+extern bool lock_target;
 extern bool ready;
 extern bool use_nvidia;
 extern float max_dist;
@@ -176,6 +177,8 @@ void Overlay::RenderMenu()
 			{
 				ImGui::SameLine();
 				ImGui::Checkbox(XorStr("Visibility check"), &vis_check);
+				ImGui::SameLine();
+				ImGui::Checkbox(XorStr("Lock Target"), &lock_target);
 				ImGui::SameLine();
 				ImGui::Checkbox(XorStr("No recoil/sway"), &aim_no_recoil);
 				if (vis_check)


### PR DESCRIPTION
This change implements a "Lock Target" feature for the aimbot. When enabled, the aimbot will stick to the current target even if another target becomes closer to the crosshair, as long as the first target remains valid. This is controlled by a new checkbox in the 'Main' tab of the guest UI.

---
*PR created automatically by Jules for task [15693507787140268806](https://jules.google.com/task/15693507787140268806) started by @albatror*