### PR TITLE
Update NVIDIA GPU Spoofing for Multi-Version Support (53x-56x+)

### DIFF
--- a/apex_dma/spoof.cpp
+++ b/apex_dma/spoof.cpp
@@ -69,15 +69,19 @@ bool spoof_gpu_uuid(std::string &real_uuid, std::string &fake_uuid) {
         return false;
     }
 
-    // Resolve GpuMgrGetGpuFromId address from the call located near pattern + 0x3B
+    // Resolve GpuMgrGetGpuFromId address from the call/jmp located near pattern + 0x3B
     uint64_t GpuMgrGetGpuFromId_addr = 0;
-    for (int i = 0; i < 128; i++) {
+    for (int i = 0; i < 256; i++) {
         size_t off = pattern_off + 0x3B + i;
         if (off + 5 >= scan_size) break;
-        if (module_data[off] == 0xE8) {
+        uint8_t op = module_data[off];
+        if (op == 0xE8 || op == 0xE9) {
+            // Avoid false positives from filler bytes (0xCC)
+            if (off > 0 && module_data[off-1] == 0xCC) continue;
+
             int32_t rel_offset = *(int32_t*)&module_data[off + 1];
             GpuMgrGetGpuFromId_addr = module_info.base + off + 5 + rel_offset;
-            printf("GpuMgrGetGpuFromId resolved to: %lx (from call at +%zx)\n", GpuMgrGetGpuFromId_addr, off);
+            printf("GpuMgrGetGpuFromId resolved to: %lx (from %s at +%zx)\n", GpuMgrGetGpuFromId_addr, op == 0xE8 ? "call" : "jmp", off);
             break;
         }
     }
@@ -92,7 +96,7 @@ bool spoof_gpu_uuid(std::string &real_uuid, std::string &fake_uuid) {
     // Scan for UuidValidOffset near the pattern
     uint32_t uuid_valid_offset = 0;
     size_t scan_start_off = (pattern_off > 0x200) ? pattern_off - 0x200 : 0;
-    size_t scan_end_off = std::min(pattern_off + 0x400, scan_size);
+    size_t scan_end_off = std::min(pattern_off + 0x300, scan_size);
 
     for (size_t i = scan_start_off; i < scan_end_off - 7; i++) {
         // Pattern 1: 80 BB ?? ?? 00 00 00
@@ -151,7 +155,7 @@ bool spoof_gpu_uuid(std::string &real_uuid, std::string &fake_uuid) {
         uint64_t gpu_array = 0;
         kernel->read_raw_into(gpu_array_ptr, CSliceMut<uint8_t>((char*)&gpu_array, 8));
         if (gpu_array) {
-            for (int i = 0; i < 32; i++) {
+            for (int i = 0; i < 64; i++) {
                 uint64_t gpu_object = 0;
                 kernel->read_raw_into(gpu_array + (i * 8), CSliceMut<uint8_t>((char*)&gpu_object, 8));
                 if (gpu_object) {


### PR DESCRIPTION
I have updated the NVIDIA GPU spoofing implementation in `apex_dma/spoof.cpp` to align with the "multi-version support (53x-56x+)" logic described in the UnknownCheats post. 

The implementation was already very robust but required several refinements to perfectly match the latest driver requirements:
- **Extended Instruction Search**: The search for the GPU resolution function now covers 256 bytes and correctly identifies both CALL and JMP instructions.
- **Improved Pattern Matching**: I added a check to ignore 0xCC padding bytes, which prevents incorrect address calculation on certain driver versions.
- **Increased Scalability**: The primary spoofing loop now iterates through up to 64 potential GPU objects.
- **Refined Scan Windows**: The UUID valid offset discovery range has been calibrated to the specific window (+0x300) recommended in the post.

The code has been verified and successfully compiled against the latest `memflow` dependencies.

---
*PR created automatically by Jules for task [1758859354543630044](https://jules.google.com/task/1758859354543630044) started by @albatror*