### PR TITLE
Update weapon IDs and names

### DIFF
--- a/apex_dma/StuffBot.cpp
+++ b/apex_dma/StuffBot.cpp
@@ -80,11 +80,11 @@ bool isAllowedWeapon(int weaponId, int zoomElapsedMs) {
         weaponId == WeaponIDs::LONGBOW ||
         weaponId == WeaponIDs::SENTINEL ||
         weaponId == WeaponIDs::G7_SCOUT ||
-        weaponId == WeaponIDs::HEMLOK ||
+        weaponId == WeaponIDs::HEMLOCK ||
         weaponId == WeaponIDs::REPEATER_3030 ||
         weaponId == WeaponIDs::TRIPLE_TAKE ||
         weaponId == WeaponIDs::BOCEK ||
-        weaponId == WeaponIDs::THROWING_KNIFE ||
+        weaponId == WeaponIDs::KNIFE ||
         weaponId == WeaponIDs::P2020 ||
         weaponId == WeaponIDs::MOZAMBIQUE ||
         weaponId == WeaponIDs::EVA8 ||

--- a/apex_dma/Weapon.h
+++ b/apex_dma/Weapon.h
@@ -2,43 +2,71 @@
 #include <string>
 #include <unordered_map>
 
-enum WeaponIDs {
-    SENTINEL = 1,
-    THROWING_KNIFE = 2,
-    LONGBOW = 89,
-    EVA8 = 92,
-    G7_SCOUT = 95,
-    HEMLOK = 96,
-    KRABER = 98,
-    MASTIFF = 101,
-    MOZAMBIQUE = 103,
-    PEACEKEEPER = 111,
-    P2020 = 114,
-    TRIPLE_TAKE = 116,
-    WINGMAN = 117,
-    REPEATER_3030 = 120,
-    NEMESIS = 122,
-    BOCEK = 182,
-};
+namespace WeaponIDs {
+    inline constexpr int P2020 = 119;
+    inline constexpr int ALTERNATOR = 86;
+    inline constexpr int R99 = 117;
+    inline constexpr int R301 = 0;
+    inline constexpr int SPITFIRE = 121;
+    inline constexpr int G7_SCOUT = 100;
+    inline constexpr int FLATLINE = 98;
+    inline constexpr int HEMLOCK = 101;
+    inline constexpr int PROWLER = 113;
+    inline constexpr int REPEATER_3030 = 127;
+    inline constexpr int RAMPAGE = 7;
+    inline constexpr int CAR = 130;
+    inline constexpr int RE45 = 87;
+    inline constexpr int HAVOC = 94;
+    inline constexpr int DEVOTION = 91;
+    inline constexpr int LSTAR = 104;
+    inline constexpr int TRIPLE_TAKE = 122;
+    inline constexpr int VOLT = 126;
+    inline constexpr int NEMESIS = 131;
+    inline constexpr int MOZAMBIQUE = 108;
+    inline constexpr int PEACEKEEPER = 115;
+    inline constexpr int MASTIFF = 106;
+    inline constexpr int EVA8 = 96;
+    inline constexpr int LONGBOW = 93;
+    inline constexpr int CHARGE_RIFLE = 90;
+    inline constexpr int SENTINEL = 2;
+    inline constexpr int WINGMAN = 124;
+    inline constexpr int BOCEK = 3;
+    inline constexpr int KRABER = 103;
+    inline constexpr int KNIFE = 198;
+}
 
 inline std::string get_weapon_name(int id) {
     static const std::unordered_map<int, std::string> weapon_map = {
-        {WeaponIDs::SENTINEL, "Sentinel"},
-        {WeaponIDs::THROWING_KNIFE, "Throwing Knife"},
-        {WeaponIDs::LONGBOW, "Longbow"},
-        {WeaponIDs::EVA8, "EVA-8 Auto"},
+        {WeaponIDs::P2020, "P2020"},
+        {WeaponIDs::ALTERNATOR, "Alternator SMG"},
+        {WeaponIDs::R99, "R-99 SMG"},
+        {WeaponIDs::R301, "R-301 Carbine"},
+        {WeaponIDs::SPITFIRE, "M600 Spitfire"},
         {WeaponIDs::G7_SCOUT, "G7 Scout"},
-        {WeaponIDs::HEMLOK, "Hemlok"},
-        {WeaponIDs::KRABER, "Kraber"},
-        {WeaponIDs::MASTIFF, "Mastiff"},
+        {WeaponIDs::FLATLINE, "VK-47 Flatline"},
+        {WeaponIDs::HEMLOCK, "Hemlock Burst AR"},
+        {WeaponIDs::PROWLER, "Prowler Burst PDW"},
+        {WeaponIDs::REPEATER_3030, "30-30 Repeater"},
+        {WeaponIDs::RAMPAGE, "Rampage LMG"},
+        {WeaponIDs::CAR, "C.A.R. SMG"},
+        {WeaponIDs::RE45, "RE-45 Auto"},
+        {WeaponIDs::HAVOC, "Havoc Rifle"},
+        {WeaponIDs::DEVOTION, "Devotion LMG"},
+        {WeaponIDs::LSTAR, "L-STAR EMG"},
+        {WeaponIDs::TRIPLE_TAKE, "Triple Take"},
+        {WeaponIDs::VOLT, "Volt SMG"},
+        {WeaponIDs::NEMESIS, "Nemesis Burst AR"},
         {WeaponIDs::MOZAMBIQUE, "Mozambique"},
         {WeaponIDs::PEACEKEEPER, "Peacekeeper"},
-        {WeaponIDs::P2020, "P2020"},
-        {WeaponIDs::TRIPLE_TAKE, "Triple Take"},
+        {WeaponIDs::MASTIFF, "Mastiff Shotgun"},
+        {WeaponIDs::EVA8, "EVA-8 Auto"},
+        {WeaponIDs::LONGBOW, "Longbow DMR"},
+        {WeaponIDs::CHARGE_RIFLE, "Charge Rifle"},
+        {WeaponIDs::SENTINEL, "Sentinel"},
         {WeaponIDs::WINGMAN, "Wingman"},
-        {WeaponIDs::REPEATER_3030, "30-30 Repeater"},
-        {WeaponIDs::NEMESIS, "Nemesis"},
-        {WeaponIDs::BOCEK, "Bocek"}
+        {WeaponIDs::BOCEK, "Bocek Compound Bow"},
+        {WeaponIDs::KRABER, "Kraber .50-Cal Sniper"},
+        {WeaponIDs::KNIFE, "Throwing Knife"}
     };
     auto it = weapon_map.find(id);
     if (it != weapon_map.end()) return it->second;


### PR DESCRIPTION
This change updates the weapon identification system in `apex_dma` to align with the latest game data. It updates `Weapon.h` with new IDs and names and adjusts `StuffBot.cpp` to use the updated constant names.

---
*PR created automatically by Jules for task [7124560245546580311](https://jules.google.com/task/7124560245546580311) started by @albatror*