### PR TITLE
Restore default item glow colors

### DIFF
--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -1606,17 +1606,17 @@ void item_glow_t()
 
 						if (item.isBox())
 						{
-							highlightID = 38; // Red
+							highlightID = 14; // Legendary/Orange
 						}
 						else
 						{
-							// Rarity based IDs
-							if (scriptInt == 1) highlightID = 34; // White
-							else if (scriptInt == 2) highlightID = 35; // Blue
-							else if (scriptInt == 3) highlightID = 36; // Purple
-							else if (scriptInt == 4) highlightID = 37; // Yellow
-							else if (scriptInt >= 5) highlightID = 38; // Red
-							else highlightID = 65;
+							// Rarity based IDs (Default game IDs)
+							if (scriptInt == 1) highlightID = 11;      // White
+							else if (scriptInt == 2) highlightID = 12; // Blue
+							else if (scriptInt == 3) highlightID = 13; // Purple
+							else if (scriptInt == 4) highlightID = 14; // Yellow/Orange
+							else if (scriptInt >= 5) highlightID = 15; // Red
+							else highlightID = 11;
 						}
 						item.enableGlow(highlightID);
 					}

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -1588,21 +1588,6 @@ void item_glow_t()
 			std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
 			uint64_t entitylist = g_Base + OFFSET_ENTITYLIST;
-			uint64_t highlightSettingsPtr = 0;
-			apex_mem.Read<uint64_t>(g_Base + HIGHLIGHT_SETTINGS, highlightSettingsPtr);
-			if (highlightSettingsPtr == 0) continue;
-
-			// White, Blue, Purple, Yellow, Red
-			const std::vector<uint8_t> itemHighlightIDs = { 34, 35, 36, 37, 38 };
-			const GlowMode itemGlowMode = { 137, 138, 64, 64 };
-
-			for (uint8_t id : itemHighlightIDs)
-			{
-				GlowMode currentGlowMode;
-				apex_mem.Read<GlowMode>(highlightSettingsPtr + HIGHLIGHT_TYPE_SIZE * id + 0, currentGlowMode);
-				if (currentGlowMode != itemGlowMode)
-					apex_mem.Write<GlowMode>(highlightSettingsPtr + HIGHLIGHT_TYPE_SIZE * id + 0, itemGlowMode);
-			}
 
 			for (int i = 0; i < 10000; i++)
 			{


### PR DESCRIPTION
The hardcoded GlowMode override `{ 137, 138, 64, 64 }` for item highlight indices 34-38 was removed from `apex_dma/apex_dma.cpp`. This allows the game to use its default highlight definitions (such as the preferred orange legendary highlight) while the cheat still enables visibility through walls via `item.enableGlow()`.

---
*PR created automatically by Jules for task [14668172220319634767](https://jules.google.com/task/14668172220319634767) started by @albatror*