### PR TITLE
Add skeleton thickness parameter and host-guest synchronization

### DIFF
--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -37,6 +37,7 @@ const int toRead = 100;
 int aim = false;
 bool esp = false;
 bool skeleton = false;
+float skeleton_thickness = 1.0f;
 bool item_glow = false;
 bool player_glow = false;
 bool aim_no_recoil = true;
@@ -1402,6 +1403,12 @@ if(!client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 57, flickbot_delay_a
   printf("Read failed!\n");
 }
 
+uint64_t skeleton_thickness_addr = 0;
+printf("Reading skeleton_thickness address: %lx\n", add_addr + sizeof(uint64_t) * 63);
+if(!client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 63, skeleton_thickness_addr)) {
+  printf("Read failed!\n");
+}
+
 ////////
 
 uint64_t onevone_addr = 0;
@@ -1572,6 +1579,8 @@ while (vars_t)
         if (flickbot_flickback_delay_addr) client_mem.Read<int>(flickbot_flickback_delay_addr, flickbot_flickback_delay);
 
         if (flickbot_delay_addr) client_mem.Read<int>(flickbot_delay_addr, flickbot_delay);
+
+        if (skeleton_thickness_addr) client_mem.Read<float>(skeleton_thickness_addr, skeleton_thickness);
 
         if (esp && next)
         {

--- a/apex_guest/Client/Client/config.cpp
+++ b/apex_guest/Client/Client/config.cpp
@@ -95,6 +95,7 @@ void SaveConfig(const std::string& filename) {
     file << "platform " << std::boolalpha << v.platform << "\n";
     file << "line " << std::boolalpha << v.line << "\n";
     file << "skeleton " << std::boolalpha << v.skeleton << "\n";
+    file << "skeleton_thickness " << v.skeleton_thickness << "\n";
     file << "spectator_notifier " << std::boolalpha << v.spectator_notifier << "\n";
     file << "info_window " << std::boolalpha << v.info_window << "\n";
     file << "target_indicator " << std::boolalpha << v.target_indicator << "\n";
@@ -170,6 +171,7 @@ void LoadConfig(const std::string& filename) {
         else if (key == "platform") ss >> std::boolalpha >> v.platform;
         else if (key == "line") ss >> std::boolalpha >> v.line;
         else if (key == "skeleton") ss >> std::boolalpha >> v.skeleton;
+        else if (key == "skeleton_thickness") ss >> v.skeleton_thickness;
         else if (key == "spectator_notifier") ss >> std::boolalpha >> v.spectator_notifier;
         else if (key == "info_window") ss >> std::boolalpha >> v.info_window;
         else if (key == "target_indicator") ss >> std::boolalpha >> v.target_indicator;

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -396,7 +396,7 @@ void Overlay::RenderEsp()
 							{
 								DrawLine(ImVec2(players[i].bones[line[0]][0], players[i].bones[line[0]][1]),
 									ImVec2(players[i].bones[line[1]][0], players[i].bones[line[1]][1]),
-									skelColor, 1.0f);
+									skelColor, v.skeleton_thickness);
 							}
 						}
 					}
@@ -521,6 +521,7 @@ int main(int argc, char** argv)
 	add[54] = (uintptr_t)&flickbot_flickback;
 	add[55] = (uintptr_t)&flickbot_flickback_delay;
 	add[57] = (uintptr_t)&flickbot_delay;
+	add[63] = (uintptr_t)&v.skeleton_thickness;
 
 	printf(XorStr("add offset: 0x%I64x\n"), (uint64_t)&add[0] - (uint64_t)GetModuleHandle(NULL));
 

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -308,6 +308,10 @@ void Overlay::RenderMenu()
 			ImGui::Checkbox(XorStr("Shield bar"), &v.shieldbar);
 
 			ImGui::Checkbox(XorStr("Skeleton"), &v.skeleton);
+			if (v.skeleton) {
+				ImGui::SameLine();
+				ImGui::SliderFloat(XorStr("Skeleton Thickness"), &v.skeleton_thickness, 1.0f, 10.0f, "%.1f");
+			}
 			ImGui::Checkbox(XorStr("Line"), &v.line);
 
 			ImGui::Checkbox(XorStr("Spectator list"), &v.spectator_notifier);

--- a/apex_guest/Client/Client/overlay.h
+++ b/apex_guest/Client/Client/overlay.h
@@ -40,6 +40,7 @@ typedef struct visuals
 	float target_indicator_fov = 10.0f;
 	bool flickbot_fov_circle = false;
 	bool triggerbot_fov_circle = false;
+	float skeleton_thickness = 1.0f;
 }visuals;
 
 struct GColor {


### PR DESCRIPTION
This change adds a user-configurable parameter for skeleton thickness in the ESP overlay. It includes UI controls in the guest client, persistence in the configuration file, and synchronization to the host DMA server.

---
*PR created automatically by Jules for task [14585119364267166678](https://jules.google.com/task/14585119364267166678) started by @albatror*