### PR TITLE
Implement Weapon ESP for Enemies

### DIFF
--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -9,6 +9,7 @@
 #include "offsets_dynamic.h"
 #include "Game.h"
 #include "StuffBot.h"
+#include "Weapon.h"
 #include "ItemManager.h"
 #include <thread>
 #include <array>
@@ -159,6 +160,7 @@ typedef struct player
 	int player_xp_level = 0;
 	int platform = 0;
 	char name[33] = { 0 };
+	char weapon[33] = { 0 };
 	float bones[15][2] = { 0 };
 }player;
 
@@ -855,6 +857,16 @@ Entity LPlayer = getEntity(LocalPlayer);
 							}
 
 							Target.get_name(g_Base, &players[c].name[0]);
+
+							char weaponModel[256] = { 0 };
+							Target.getWeaponModelName(weaponModel, 256);
+							std::string weaponName = get_weapon_name_by_model(weaponModel);
+							if (weaponName == "Unknown") {
+								int weaponId = Target.getCurrentWeaponId();
+								weaponName = get_weapon_name(weaponId);
+							}
+							strncpy(players[c].weapon, weaponName.c_str(), 32);
+
 							lastvis_esp[c] = Target.lastVisTime();
 							valid = true;
 							c++;
@@ -964,6 +976,16 @@ Entity LPlayer = getEntity(LocalPlayer);
 							}
 
 							Target.get_name(g_Base, &players[i].name[0]);
+
+							char weaponModel[256] = { 0 };
+							Target.getWeaponModelName(weaponModel, 256);
+							std::string weaponName = get_weapon_name_by_model(weaponModel);
+							if (weaponName == "Unknown") {
+								int weaponId = Target.getCurrentWeaponId();
+								weaponName = get_weapon_name(weaponId);
+							}
+							strncpy(players[i].weapon, weaponName.c_str(), 32);
+
 							lastvis_esp[i] = Target.lastVisTime();
 							valid = true;
 						}

--- a/apex_guest/Client/Client/config.cpp
+++ b/apex_guest/Client/Client/config.cpp
@@ -91,6 +91,7 @@ void SaveConfig(const std::string& filename) {
     file << "bone " << bone << "\n";
     file << "healthbar " << std::boolalpha << v.healthbar << "\n";
     file << "shieldbar " << std::boolalpha << v.shieldbar << "\n";
+    file << "weapon " << std::boolalpha << v.weapon << "\n";
     file << "distance " << std::boolalpha << v.distance << "\n";
     file << "platform " << std::boolalpha << v.platform << "\n";
     file << "line " << std::boolalpha << v.line << "\n";
@@ -167,6 +168,7 @@ void LoadConfig(const std::string& filename) {
         else if (key == "bone") ss >> bone;
         else if (key == "healthbar") ss >> std::boolalpha >> v.healthbar;
         else if (key == "shieldbar") ss >> std::boolalpha >> v.shieldbar;
+        else if (key == "weapon") ss >> std::boolalpha >> v.weapon;
         else if (key == "distance") ss >> std::boolalpha >> v.distance;
         else if (key == "platform") ss >> std::boolalpha >> v.platform;
         else if (key == "line") ss >> std::boolalpha >> v.line;

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -30,6 +30,7 @@ typedef struct player
 	int xp_level = 0;
 	int platform = 0;
 	char name[33] = { 0 };
+	char weapon[33] = { 0 };
 	float bones[15][2] = { 0 };
 }player;
 
@@ -363,6 +364,14 @@ void Overlay::RenderEsp()
 							String(ImVec2(players[i].boxMiddle, (players[i].b_y + 35)), RED, platformName.c_str());
 						else
 							String(ImVec2(players[i].boxMiddle, (players[i].b_y + 35)), GREEN, platformName.c_str());
+					}
+
+					if (v.weapon)
+					{
+						if (players[i].knocked)
+							String(ImVec2(players[i].boxMiddle, (players[i].b_y + 45)), RED, players[i].weapon);
+						else
+							String(ImVec2(players[i].boxMiddle, (players[i].b_y + 45)), GREEN, players[i].weapon);
 					}
 
 					if (v.skeleton)

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -299,6 +299,8 @@ void Overlay::RenderMenu()
 			ImGui::SameLine();
 			ImGui::Checkbox(XorStr("Name"), &v.name);
 			ImGui::SameLine();
+			ImGui::Checkbox(XorStr("Weapon"), &v.weapon);
+			ImGui::SameLine();
 			ImGui::Checkbox(XorStr("Distance"), &v.distance);
 			ImGui::SameLine();
 			ImGui::Checkbox(XorStr("Platform"), &v.platform);

--- a/apex_guest/Client/Client/overlay.h
+++ b/apex_guest/Client/Client/overlay.h
@@ -32,6 +32,7 @@ typedef struct visuals
 	bool healthbar = true;
 	bool shieldbar = true;
 	bool name = true;
+	bool weapon = false;
 	bool platform = false;
 	bool skeleton = false;
 	bool spectator_notifier = false;


### PR DESCRIPTION
This change introduces a new ESP feature that displays the name of the weapon currently held by an enemy. The weapon name is retrieved via DMA on the host side, synchronized to the guest client, and rendered in the overlay below the platform information. Users can toggle this feature through a new "Weapon" checkbox in the Visuals menu, and the preference is saved in the configuration file.

---
*PR created automatically by Jules for task [12812394512615852677](https://jules.google.com/task/12812394512615852677) started by @albatror*