### PR TITLE
Fix triggerbot and weapon printing

### DIFF
--- a/apex_dma/StuffBot.cpp
+++ b/apex_dma/StuffBot.cpp
@@ -52,54 +52,70 @@ void StuffBotLoop()
         if (triggerbot && triggerbot_aiming)
         {
             uint64_t entitylist = g_Base + OFFSET_ENTITYLIST;
-            for (int i = 0; i < 256; i++) {
+            int ent_count = firing_range ? 10000 : 100;
+            static std::unordered_map<uint64_t, float> last_crosshair_times;
+
+            for (int i = 0; i < ent_count; i++) {
                 uint64_t centity = 0;
                 if (!apex_mem.Read<uint64_t>(entitylist + ((uint64_t)i << 5), centity) || centity == 0 || centity == LocalPlayer) continue;
 
-                // Targeted reads to avoid getEntity overhead
-                int health = 0;
-                apex_mem.Read<int>(centity + OFFSET_HEALTH, health);
-                if (health <= 0) continue;
-
-                int team = 0;
-                apex_mem.Read<int>(centity + OFFSET_TEAM, team);
-                if (team == LPlayer.getTeamId() && !firing_range) continue;
-
-                // Dummy check if firing range
-                if (firing_range) {
-                    char class_name[33] = {};
-                    get_class_name(centity, class_name);
-                    if (strncmp(class_name, "CAI_BaseNPC", 11) != 0) continue;
-                }
-
-                // Check FOV
-                Vector EntityPosition;
-                apex_mem.Read<Vector>(centity + OFFSET_ORIGIN, EntityPosition);
-                float fov = Math::GetFov(LPlayer.GetViewAngles(), Math::CalcAngle(LPlayer.GetCamPos(), EntityPosition));
-                if (fov > triggerbot_fov) continue;
-
-                // Finally check crosshair
+                // First check crosshair timestamp - fast read
                 float now_crosshair_target_time = 0;
-                apex_mem.Read<float>(centity + OFFSET_CROSSHAIR_LAST, now_crosshair_target_time);
+                if (!apex_mem.Read<float>(centity + OFFSET_CROSSHAIR_LAST, now_crosshair_target_time)) continue;
 
-                static std::unordered_map<uint64_t, float> last_crosshair_times;
                 if (last_crosshair_times.find(centity) == last_crosshair_times.end()) {
                     last_crosshair_times[centity] = now_crosshair_target_time;
                     continue;
                 }
 
                 if (now_crosshair_target_time > last_crosshair_times[centity]) {
-                    char weaponModel[256] = { 0 };
-                    LPlayer.getWeaponModelName(weaponModel, 256);
-                    std::string weaponName = get_weapon_name_by_model(weaponModel);
-                    if (weaponName == "Unknown") {
-                        int weaponId = LPlayer.getCurrentWeaponId();
-                        weaponName = get_weapon_name(weaponId);
+                    // Possible target detected by crosshair, now perform detailed checks
+                    int health = 0;
+                    apex_mem.Read<int>(centity + OFFSET_HEALTH, health);
+                    if (health <= 0) {
+                        last_crosshair_times[centity] = now_crosshair_target_time;
+                        continue;
                     }
-                    printf("[TRIGGERBOT] Shooting at entity %d with weapon %s\n", i, weaponName.c_str());
-                    TriggerBotRun();
-                    last_crosshair_times[centity] = now_crosshair_target_time;
-                    break;
+
+                    int team = 0;
+                    apex_mem.Read<int>(centity + OFFSET_TEAM, team);
+                    if (team == LPlayer.getTeamId() && !firing_range) {
+                        last_crosshair_times[centity] = now_crosshair_target_time;
+                        continue;
+                    }
+
+                    // Dummy check if firing range
+                    if (firing_range) {
+                        char class_name[33] = {};
+                        get_class_name(centity, class_name);
+                        if (strncmp(class_name, "CAI_BaseNPC", 11) != 0) {
+                            last_crosshair_times[centity] = now_crosshair_target_time;
+                            continue;
+                        }
+                    }
+
+                    // Check FOV using head bone for better accuracy
+                    Entity Target = getEntity(centity);
+                    Vector HeadPos = Target.getBonePositionByHitbox(0);
+                    if (HeadPos.IsZero()) {
+                        last_crosshair_times[centity] = now_crosshair_target_time;
+                        continue;
+                    }
+
+                    float fov = Math::GetFov(LPlayer.GetViewAngles(), Math::CalcAngle(LPlayer.GetCamPos(), HeadPos));
+                    if (fov <= triggerbot_fov) {
+                        char weaponModel[256] = { 0 };
+                        LPlayer.getWeaponModelName(weaponModel, 256);
+                        std::string weaponName = get_weapon_name_by_model(weaponModel);
+                        if (weaponName == "Unknown" || weaponName == "unknown") {
+                            int weaponId = LPlayer.getCurrentWeaponId();
+                            weaponName = get_weapon_name(weaponId);
+                        }
+                        printf("[TRIGGERBOT] Shooting at entity %d (time: %f) with weapon %s\n", i, now_crosshair_target_time, weaponName.c_str());
+                        TriggerBotRun();
+                        last_crosshair_times[centity] = now_crosshair_target_time;
+                        break;
+                    }
                 }
                 last_crosshair_times[centity] = now_crosshair_target_time;
             }

--- a/apex_dma/offsets.h
+++ b/apex_dma/offsets.h
@@ -49,7 +49,7 @@
 #define OFFSET_IN_JUMP 0x3c74290 //[Buttons].in_jump updated 2026/03/24
 #define OFFSET_IN_TOGGLE_DUCK 0x3c741a8 //[Buttons].in_toggle_duck updated 2026/03/24
  
-#define OFFSET_WEAPON_NAME 0x15f0 //?0x19c4 //[RecvTable.DT_WeaponX].m_weaponNameIndex updated 2026/03/24
+#define OFFSET_WEAPON_NAME 0x1888 //?0x19c4 //[RecvTable.DT_WeaponX].m_weaponNameIndex updated 2026/03/24
 #define OFFSET_OFF_WEAPON 0x19d4 //[DataMap.DT_BaseCombatCharacter].m_latestNonOffhandWeapons updated 2026/03/24
 #define OFFSET_WALL_RUN_START_TIME 0x370c //[RecvTable.DT_LocalPlayerExclusive]->m_wallRunStartTime updated 2026/03/24
 #define OFFSET_WALL_RUN_CLEAR_TIME 0x3710 //[RecvTable.DT_LocalPlayerExclusive]->m_wallRunClearTime updated 2026/03/24
@@ -113,7 +113,7 @@
 #define GLOW_FADE 0x388+ 0x30 // ats 3rd result of 3 offsets consecutive or first + 8 updated 01/10/2024
 #define HIGHLIGHT_SETTINGS 0x6875130 //[Miscellaneous].HighlightSettings updated 2026/03/24
 #define HIGHLIGHT_TYPE_SIZE 0x34 //? updated 01/10/2024
-#define OFFSET_CROSSHAIR_LAST OFFSET_VISIBLE_TIME + 0x19f8 //[Miscellaneous].CWeaponX!lastCrosshairTargetTime updated 2025/04/18
+#define OFFSET_CROSSHAIR_LAST 0x1a6c //[Miscellaneous].CWeaponX!lastCrosshairTargetTime updated 2025/04/18
 //#define OFFSET_CROSSHAIR_START 0x1958 //CPlayer!crosshairTargetStartTime updated 01/9/2024
 #define OFFSET_INPUT_SYSTEM 0x1dc4d80 //[Miscellaneous].InputSystem updated 2026/03/24 
 


### PR DESCRIPTION
The triggerbot was failing due to an incorrect `OFFSET_CROSSHAIR_LAST` and an insufficient entity scan range in the firing range. Additionally, weapon names were not printing because of an outdated `OFFSET_WEAPON_NAME`. This PR updates the offsets and refines the triggerbot logic for better performance and reliability.

---
*PR created automatically by Jules for task [17284283190553107184](https://jules.google.com/task/17284283190553107184) started by @albatror*