### PR TITLE
Implement Simple Heirloom Changer

### DIFF
--- a/apex_dma/ItemManager.cpp
+++ b/apex_dma/ItemManager.cpp
@@ -1,9 +1,12 @@
 #include "ItemManager.h"
 #include "ItemID.h"
+#include "memory.h"
+#include "offsets.h"
 #include <fstream>
 #include <sstream>
 #include <iostream>
 #include <algorithm>
+#include <cstdint>
 
 ItemManager::ItemManager() {
     LoadItems("items.ini");

--- a/apex_dma/ItemManager.cpp
+++ b/apex_dma/ItemManager.cpp
@@ -124,3 +124,43 @@ bool ItemManager::GetItemInfoByID(int id, std::string& name, ItemCategory& categ
 
     return true;
 }
+
+int ItemManager::GetModelIndex(const std::string& search_str) {
+    auto it = modelIndexCache.find(search_str);
+    if (it != modelIndexCache.end()) {
+        return it->second;
+    }
+
+    extern uint64_t g_Base;
+    extern Memory apex_mem;
+    uint64_t entitylist = g_Base + OFFSET_ENTITYLIST;
+
+    for (int i = 0; i < 2000; i++) {
+        uint64_t centity = 0;
+        apex_mem.Read<uint64_t>(entitylist + ((uint64_t)i << 5), centity);
+        if (centity == 0) continue;
+
+        uint64_t m_ptr = 0;
+        apex_mem.Read<uint64_t>(centity + OFFSET_MODELNAME, m_ptr);
+        if (m_ptr == 0) continue;
+
+        char modelName[256] = { 0 };
+        apex_mem.ReadArray<char>(m_ptr, modelName, 256);
+        std::string model_str = std::string(modelName);
+
+        if (model_str.find(search_str) != std::string::npos) {
+            int modelIndex = 0;
+            apex_mem.Read<int>(centity + OFFSET_MODEL_INDEX, modelIndex);
+            if (modelIndex != 0) {
+                modelIndexCache[search_str] = modelIndex;
+                return modelIndex;
+            }
+        }
+    }
+
+    return 0;
+}
+
+void ItemManager::ResetModelCache() {
+    modelIndexCache.clear();
+}

--- a/apex_dma/ItemManager.h
+++ b/apex_dma/ItemManager.h
@@ -40,10 +40,13 @@ public:
     void LoadWeapons(const std::string& path);
     bool GetItemInfo(const std::string& modelName, std::string& name, ItemCategory& category);
     bool GetItemInfoByID(int id, std::string& name, ItemCategory& category);
+    int GetModelIndex(const std::string& search_str);
+    void ResetModelCache();
 
 private:
     ItemManager();
     ItemCategory DetermineCategory(const std::string& name, int glowId);
     std::vector<ItemDef> itemDefs;
     std::unordered_map<std::string, std::pair<std::string, ItemCategory>> cache;
+    std::unordered_map<std::string, int> modelIndexCache;
 };

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -87,6 +87,7 @@ float triggerbot_fov = 10.0f;
 bool superglide = false;
 bool bhop = false;
 bool walljump = false;
+bool heirloom_changer = false;
 
 ///////////
 //bool medbackpack = true;
@@ -589,6 +590,39 @@ if (isGrappling && grappleAttached == 1) {
 }
 
 //grapple END/////////////////////////////
+
+// Heirloom Changer
+if (heirloom_changer) {
+    uint32_t view_model_handle = 0;
+    if (apex_mem.Read<uint32_t>(LocalPlayer + OFFSET_VIEWMODEL, view_model_handle)) {
+        view_model_handle &= 0xFFFF;
+        if (view_model_handle != 0xFFFF) {
+            uint64_t view_model_ptr = 0;
+            if (apex_mem.Read<uint64_t>(g_Base + OFFSET_ENTITYLIST + (view_model_handle << 5), view_model_ptr) && view_model_ptr != 0) {
+                uint64_t name_ptr = 0;
+                if (apex_mem.Read<uint64_t>(view_model_ptr + OFFSET_MODELNAME, name_ptr) && name_ptr != 0) {
+                    char modelName[200];
+                    if (apex_mem.ReadArray<char>(name_ptr, modelName, 200)) {
+                        std::string model_name_str = std::string(modelName);
+                        if (model_name_str.find("empty_handed") != std::string::npos) {
+                            const char* heirloom_path = "mdl/techart/mshop/weapons/class/heirloom/agnostic/v24_cosmicmerc/heirloom_karambit_v24_cosmicmerc_v.rmdl";
+                            apex_mem.WriteArray<char>(name_ptr, (char*)heirloom_path, strlen(heirloom_path) + 1);
+                            apex_mem.Write<int>(view_model_ptr + OFFSET_CURFRAME, 5272);
+                        } else if (model_name_str.find("heirloom_karambit_v24_cosmicmerc_v") != std::string::npos) {
+                            int cur_sequence = 0;
+                            apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, cur_sequence);
+                            int modelAniIndex = 0;
+                            apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_MODEL_INDEX, modelAniIndex);
+                            if (cur_sequence == 0 && modelAniIndex == 5272) {
+                                apex_mem.Write<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, 82);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
 
 //bhop///
 if (bhop && SuperKey) {
@@ -1425,6 +1459,12 @@ if(!client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 57, flickbot_delay_a
   printf("Read failed!\n");
 }
 
+uint64_t heirloom_changer_addr = 0;
+printf("Reading heirloom_changer address: %lx\n", add_addr + sizeof(uint64_t) * 56);
+if(!client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 56, heirloom_changer_addr)) {
+  printf("Read failed!\n");
+}
+
 uint64_t skeleton_thickness_addr = 0;
 printf("Reading skeleton_thickness address: %lx\n", add_addr + sizeof(uint64_t) * 63);
 if(!client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 63, skeleton_thickness_addr)) {
@@ -1601,6 +1641,8 @@ while (vars_t)
         if (flickbot_flickback_delay_addr) client_mem.Read<int>(flickbot_flickback_delay_addr, flickbot_flickback_delay);
 
         if (flickbot_delay_addr) client_mem.Read<int>(flickbot_delay_addr, flickbot_delay);
+
+        if (heirloom_changer_addr) client_mem.Read<bool>(heirloom_changer_addr, heirloom_changer);
 
         if (skeleton_thickness_addr) client_mem.Read<float>(skeleton_thickness_addr, skeleton_thickness);
 

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -375,6 +375,12 @@ void DoActions()
 			apex_mem.ReadArray<char>(MapName_ptr, MapName, 200);
 					
 			//printf("%s\n", MapName);
+			static char LastMapName[200] = { 0 };
+			if (strcmp(MapName, LastMapName) != 0) {
+				ItemManager::getInstance().ResetModelCache();
+				strcpy(LastMapName, MapName);
+			}
+
 			if (strcmp(MapName, "mp_rr_tropic_island_mu1_storm") == 0) 
 			{
 				map = 1;
@@ -605,15 +611,17 @@ if (heirloom_changer) {
                     if (apex_mem.ReadArray<char>(name_ptr, modelName, 200)) {
                         std::string model_name_str = std::string(modelName);
                         if (model_name_str.find("empty_handed") != std::string::npos) {
-                            const char* heirloom_path = "mdl/techart/mshop/weapons/class/heirloom/agnostic/v24_cosmicmerc/heirloom_karambit_v24_cosmicmerc_v.rmdl";
-                            apex_mem.WriteArray<char>(name_ptr, (char*)heirloom_path, strlen(heirloom_path) + 1);
-                            apex_mem.Write<int>(view_model_ptr + OFFSET_CURFRAME, 5272);
+                            int heirloom_model_index = ItemManager::getInstance().GetModelIndex("heirloom_karambit_v24_cosmicmerc_v");
+                            if (heirloom_model_index != 0) {
+                                apex_mem.Write<int>(view_model_ptr + OFFSET_MODEL_INDEX, heirloom_model_index);
+                                apex_mem.Write<int>(view_model_ptr + OFFSET_CURFRAME, heirloom_model_index);
+                                apex_mem.Write<int>(view_model_ptr + OFFSET_ANIM_MODEL_INDEX, heirloom_model_index);
+                                apex_mem.Write<int>(view_model_ptr + OFFSET_SEQUENCE_FINISHED, 1);
+                            }
                         } else if (model_name_str.find("heirloom_karambit_v24_cosmicmerc_v") != std::string::npos) {
                             int cur_sequence = 0;
                             apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, cur_sequence);
-                            int modelAniIndex = 0;
-                            apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_MODEL_INDEX, modelAniIndex);
-                            if (cur_sequence == 0 && modelAniIndex == 5272) {
+                            if (cur_sequence == 0) {
                                 apex_mem.Write<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, 82);
                             }
                         }

--- a/apex_dma/offsets.h
+++ b/apex_dma/offsets.h
@@ -119,6 +119,8 @@
 
 #define OFFSET_VIEWMODEL 0x2e00 //[RecvTable.DT_Player].m_hViewModels updated 2026/03/24
 #define OFFSET_CURFRAME 0xd8 // [DataMap.CBaseViewModel].m_currentFrame.modelIndex
+#define OFFSET_MODEL_INDEX 0x60 // [DT_BaseEntity].m_nModelIndex
+#define OFFSET_SEQUENCE_FINISHED 0xe1c // [DT_BaseViewModel].m_bSequenceFinished
 #define OFFSET_ANIM_MODEL_INDEX 0xe40 // [DataMap.CBaseViewModel].m_currentFrameBaseAnimating.animModelIndex
 #define OFFSET_ANIM_SEQUENCE 0xe48 // [DataMap.CBaseViewModel].m_currentFrameBaseAnimating.animSequence
 

--- a/apex_dma/offsets.h
+++ b/apex_dma/offsets.h
@@ -117,6 +117,11 @@
 //#define OFFSET_CROSSHAIR_START 0x1958 //CPlayer!crosshairTargetStartTime updated 01/9/2024
 #define OFFSET_INPUT_SYSTEM 0x1dc4d80 //[Miscellaneous].InputSystem updated 2026/03/24 
 
+#define OFFSET_VIEWMODEL 0x2e00 //[RecvTable.DT_Player].m_hViewModels updated 2026/03/24
+#define OFFSET_CURFRAME 0xd8 // [DataMap.CBaseViewModel].m_currentFrame.modelIndex
+#define OFFSET_ANIM_MODEL_INDEX 0xe40 // [DataMap.CBaseViewModel].m_currentFrameBaseAnimating.animModelIndex
+#define OFFSET_ANIM_SEQUENCE 0xe48 // [DataMap.CBaseViewModel].m_currentFrameBaseAnimating.animSequence
+
 #define OFFSET_SKYDIVE_STATE 0x48b8 //[RecvTable.DT_Player].m_skydiveState updated 2026/03/24
 #define OFFSET_GRAPPLEACTIVED       0x1f10 //[RecvTable.DT_Player].m_grappleActive updated 2026/03/24
 #define OFFSET_GRAPPLE              0x1e88 //[RecvTable.DT_Player].m_grapple updated 2026/03/24

--- a/apex_guest/Client/Client/config.cpp
+++ b/apex_guest/Client/Client/config.cpp
@@ -49,6 +49,7 @@ extern bool triggerbot;
 extern bool superglide;
 extern bool bhop;
 extern bool walljump;
+extern bool heirloom_changer;
 extern float flickbot_fov;
 extern float flickbot_max_dist;
 extern bool flickbot_auto_shoot;
@@ -129,6 +130,7 @@ void SaveConfig(const std::string& filename) {
     file << "superglide " << std::boolalpha << superglide << "\n";
     file << "bhop " << std::boolalpha << bhop << "\n";
     file << "walljump " << std::boolalpha << walljump << "\n";
+    file << "heirloom_changer " << std::boolalpha << heirloom_changer << "\n";
     file << "flickbot_fov " << flickbot_fov << "\n";
     file << "flickbot_max_dist " << flickbot_max_dist << "\n";
     file << "flickbot_auto_shoot " << std::boolalpha << flickbot_auto_shoot << "\n";
@@ -206,6 +208,7 @@ void LoadConfig(const std::string& filename) {
         else if (key == "superglide") ss >> std::boolalpha >> superglide;
         else if (key == "bhop") ss >> std::boolalpha >> bhop;
         else if (key == "walljump") ss >> std::boolalpha >> walljump;
+        else if (key == "heirloom_changer") ss >> std::boolalpha >> heirloom_changer;
         else if (key == "flickbot_fov") ss >> flickbot_fov;
         else if (key == "flickbot_max_dist") ss >> flickbot_max_dist;
         else if (key == "flickbot_auto_shoot") ss >> std::boolalpha >> flickbot_auto_shoot;

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -63,6 +63,7 @@ float triggerbot_fov = 10.0f;
 bool superglide = false;
 bool bhop = false;
 bool walljump = false;
+bool heirloom_changer = false;
 
 bool use_nvidia = false;
 bool active = true;
@@ -529,6 +530,7 @@ int main(int argc, char** argv)
 	add[53] = (uintptr_t)&flickbot_auto_shoot_delay;
 	add[54] = (uintptr_t)&flickbot_flickback;
 	add[55] = (uintptr_t)&flickbot_flickback_delay;
+	add[56] = (uintptr_t)&heirloom_changer;
 	add[57] = (uintptr_t)&flickbot_delay;
 	add[63] = (uintptr_t)&v.skeleton_thickness;
 

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -43,6 +43,7 @@ extern float triggerbot_fov;
 extern bool superglide;
 extern bool bhop;
 extern bool walljump;
+extern bool heirloom_changer;
 
 //extern float esp_distance;
 
@@ -225,6 +226,7 @@ void Overlay::RenderMenu()
 			ImGui::Checkbox(XorStr("Superglide"), &superglide);
 			ImGui::Checkbox(XorStr("BHop"), &bhop);
 			ImGui::Checkbox(XorStr("WallJump"), &walljump);
+			ImGui::Checkbox(XorStr("Heirloom Changer"), &heirloom_changer);
 			ImGui::Checkbox(XorStr("Firing Range"), &firing_range);
 			ImGui::Checkbox(XorStr("1v1"), &onevone);
 			ImGui::EndTabItem();


### PR DESCRIPTION
This PR introduces a simple heirloom model replacement feature (Heirloom Changer) for the Apex Legends DMA cheat.

Key changes:
- **Host (DMA Server):** Implements logic in `apex_dma.cpp` to detect the "empty_handed" view model state and overwrite it with the model path and index for the "Cosmic Merc Karambit" heirloom. It also forces an animation update when the replacement occurs.
- **Guest (Client Client):** Adds a `heirloom_changer` boolean variable synchronized with the host via shared memory (index 56 in the `add` array).
- **UI:** Adds a toggle checkbox in the "Misc" tab of the ImGui overlay.
- **Config:** Integrates the new setting into `Settings.txt` for persistence.
- **Offsets:** Added required offsets for view model handling and animation sequencing.

---
*PR created automatically by Jules for task [12337041722798025628](https://jules.google.com/task/12337041722798025628) started by @albatror*