### PR TITLE
Refactor Triggerbot to use fixed FOV and universal prediction

### DIFF
--- a/apex_dma/StuffBot.cpp
+++ b/apex_dma/StuffBot.cpp
@@ -16,9 +16,6 @@ extern bool triggerbot;
 extern bool triggerbot_aiming;
 extern float triggerbot_fov;
 extern float aim_dist;
-extern float DDS;
-extern float min_max_fov;
-extern float max_max_fov;
 extern bool firing_range;
 extern bool is_aimentity_visible;
 bool stuff_t = false;
@@ -109,43 +106,30 @@ void StuffBotLoop()
                         continue;
                     }
 
-                    if (dist < DDS) {
-                        float distRatio = (DDS > 0.0f) ? (dist / DDS) : 0.0f;
-                        float distanceFactor = 1.0f - distRatio;
-                        float easedDistanceFactor = Math::SmoothStep(0.0f, 1.0f, distanceFactor);
-                        float fovDiff = max_max_fov - min_max_fov;
-                        float current_max_fov = min_max_fov + (fovDiff * easedDistanceFactor);
+                    if (fov <= triggerbot_fov) {
+                        WeaponXEntity curweap = WeaponXEntity();
+                        curweap.update(LPlayer.ptr);
+                        float BulletSpeed = curweap.get_projectile_speed();
+                        float BulletGrav = curweap.get_projectile_gravity();
 
-                        if (fov <= current_max_fov) {
-                            can_shoot = true;
-                        }
-                    } else {
-                        // Prediction for targets outside DDS
-                        if (fov <= triggerbot_fov) {
-                            WeaponXEntity curweap = WeaponXEntity();
-                            curweap.update(LPlayer.ptr);
-                            float BulletSpeed = curweap.get_projectile_speed();
-                            float BulletGrav = curweap.get_projectile_gravity();
+                        if (BulletSpeed > 1.f) {
+                            PredictCtx Ctx;
+                            Ctx.StartPos = LPlayer.GetCamPos();
+                            Ctx.TargetPos = HeadPos;
+                            // Scale bullet speed and gravity for prediction offset
+                            Ctx.BulletSpeed = BulletSpeed - (BulletSpeed * 0.08f);
+                            Ctx.BulletGravity = BulletGrav + (BulletGrav * 0.05f);
+                            Ctx.TargetVel = Target.getAbsVelocity();
 
-                            if (BulletSpeed > 1.f) {
-                                PredictCtx Ctx;
-                                Ctx.StartPos = LPlayer.GetCamPos();
-                                Ctx.TargetPos = HeadPos;
-                                // Scale bullet speed and gravity for prediction offset
-                                Ctx.BulletSpeed = BulletSpeed - (BulletSpeed * 0.08f);
-                                Ctx.BulletGravity = BulletGrav + (BulletGrav * 0.05f);
-                                Ctx.TargetVel = Target.getAbsVelocity();
-
-                                if (BulletPredict(Ctx)) {
-                                    QAngle PredictedAngles = QAngle{ Ctx.AimAngles.x, Ctx.AimAngles.y, 0.f };
-                                    float predicted_fov = Math::GetFov(LPlayer.GetViewAngles(), PredictedAngles);
-                                    if (predicted_fov <= triggerbot_fov) {
-                                        can_shoot = true;
-                                    }
+                            if (BulletPredict(Ctx)) {
+                                QAngle PredictedAngles = QAngle{ Ctx.AimAngles.x, Ctx.AimAngles.y, 0.f };
+                                float predicted_fov = Math::GetFov(LPlayer.GetViewAngles(), PredictedAngles);
+                                if (predicted_fov <= triggerbot_fov) {
+                                    can_shoot = true;
                                 }
-                            } else {
-                                can_shoot = true;
                             }
+                        } else {
+                            can_shoot = true;
                         }
                     }
 


### PR DESCRIPTION
The triggerbot logic in `apex_dma/StuffBot.cpp` has been simplified by removing the Dynamic Distance Scaling (DDS) system. Previously, the bot used a distance-weighted FOV threshold; it now utilizes a fixed `triggerbot_fov` for all distances. Additionally, the bullet prediction logic, which was formerly restricted to targets outside the DDS range, is now applied universally to all targets within the FOV. Unused configuration variables associated with DDS were also removed from the file.

---
*PR created automatically by Jules for task [9428014857762859451](https://jules.google.com/task/9428014857762859451) started by @albatror*