### PR TITLE
Add head circle and enhanced connections to Skeleton ESP

### DIFF
--- a/apex_dma/Game.cpp
+++ b/apex_dma/Game.cpp
@@ -13,7 +13,7 @@ extern unsigned char insidevalue;
 extern unsigned char outlinesize;
 float smooth = 12.0f;
 extern bool aim_no_recoil;
-int bone = 2;
+extern int bone;
 //
 bool bone_auto = true;
 extern float max_dist;

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -53,7 +53,7 @@ extern float smooth;
 //extern float max_smooth;
 //en stuff
 
-extern int bone;
+int bone = 2;
 bool shooting = false;
 
 //const int SuperKey = VK_SPACE;

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -156,7 +156,7 @@ typedef struct player
 	int platform = 0;
 	char name[33] = { 0 };
 	char weapon[33] = { 0 };
-	float bones[15][2] = { 0 };
+	float bones[17][2] = { 0 };
 }player;
 
 typedef struct spectator{
@@ -835,9 +835,9 @@ Entity LPlayer = getEntity(LocalPlayer);
 
 							if (skeleton)
 							{
-								// 0:Pelvis, 1:UpperChest, 2:LowerChest, 3:L_Shoulder, 4:L_Elbow, 5:L_Hand, 6:R_Shoulder, 7:R_Elbow, 8:R_Hand, 9:L_Hip, 10:L_Knee, 11:L_Foot, 12:R_Hip, 13:R_Knee, 14:R_Foot
-								int boneIDs[] = { 0, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18 };
-								for (int b = 0; b < 15; b++)
+								// 0:Head, 1:Neck, 2:UpperChest, 3:LowerChest, 4:Pelvis, 5:L_Shoulder, 6:L_Elbow, 7:L_Hand, 8:R_Shoulder, 9:R_Elbow, 10:R_Hand, 11:L_Hip, 12:L_Knee, 13:L_Foot, 14:R_Hip, 15:R_Knee, 16:R_Foot
+								int boneIDs[] = { 0, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18 };
+								for (int b = 0; b < 17; b++)
 								{
 									Vector bonePos = Target.getBonePositionByHitbox(boneIDs[b]);
 									Vector boneScreen = Vector();
@@ -954,9 +954,9 @@ Entity LPlayer = getEntity(LocalPlayer);
 
 							if (skeleton)
 							{
-								// 0:Pelvis, 1:UpperChest, 2:LowerChest, 3:L_Shoulder, 4:L_Elbow, 5:L_Hand, 6:R_Shoulder, 7:R_Elbow, 8:R_Hand, 9:L_Hip, 10:L_Knee, 11:L_Foot, 12:R_Hip, 13:R_Knee, 14:R_Foot
-								int boneIDs[] = { 0, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18 };
-								for (int b = 0; b < 15; b++)
+								// 0:Head, 1:Neck, 2:UpperChest, 3:LowerChest, 4:Pelvis, 5:L_Shoulder, 6:L_Elbow, 7:L_Hand, 8:R_Shoulder, 9:R_Elbow, 10:R_Hand, 11:L_Hip, 12:L_Knee, 13:L_Foot, 14:R_Hip, 15:R_Knee, 16:R_Foot
+								int boneIDs[] = { 0, 1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18 };
+								for (int b = 0; b < 17; b++)
 								{
 									Vector bonePos = Target.getBonePositionByHitbox(boneIDs[b]);
 									Vector boneScreen = Vector();

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -31,7 +31,7 @@ typedef struct player
 	int platform = 0;
 	char name[33] = { 0 };
 	char weapon[33] = { 0 };
-	float bones[15][2] = { 0 };
+	float bones[17][2] = { 0 };
 }player;
 
 typedef struct spectator {
@@ -367,18 +367,18 @@ void Overlay::RenderEsp()
 					{
 						ImColor skelColor = players[i].visible ? GREEN : RED;
 
-						// 0:Pelvis, 1:UpperChest, 2:LowerChest, 3:L_Shoulder, 4:L_Elbow, 5:L_Hand, 6:R_Shoulder, 7:R_Elbow, 8:R_Hand, 9:L_Hip, 10:L_Knee, 11:L_Foot, 12:R_Hip, 13:R_Knee, 14:R_Foot
+						// 0:Head, 1:Neck, 2:UpperChest, 3:LowerChest, 4:Pelvis, 5:L_Shoulder, 6:L_Elbow, 7:L_Hand, 8:R_Shoulder, 9:R_Elbow, 10:R_Hand, 11:L_Hip, 12:L_Knee, 13:L_Foot, 14:R_Hip, 15:R_Knee, 16:R_Foot
 						// Skeleton connections
 						int skeletonLines[][2] = {
-							{0, 1},  // Pelvis -> UpperChest
-							{1, 3}, {3, 4}, {4, 5}, // Left arm
-							{1, 6}, {6, 7}, {7, 8}, // Right arm
-							{0, 9}, {9, 10}, {10, 11}, // Left leg
-							{0, 12}, {12, 13}, {13, 14}, // Right leg
+							{1, 2}, {2, 3}, {3, 4}, // Spine
+							{2, 5}, {5, 6}, {6, 7}, // Left arm
+							{2, 8}, {8, 9}, {9, 10}, // Right arm
+							{4, 11}, {11, 12}, {12, 13}, // Left leg
+							{4, 14}, {14, 15}, {15, 16}, // Right leg
 						};
 
 						bool valid_skeleton = true;
-						for (int b = 0; b < 15; b++)
+						for (int b = 0; b < 17; b++)
 						{
 							// If any bone is at (0,0) or invalid, we skip the whole skeleton to avoid "starburst" artifacts
 							if (players[i].bones[b][0] <= 1.0f || players[i].bones[b][1] <= 1.0f)
@@ -396,6 +396,14 @@ void Overlay::RenderEsp()
 									ImVec2(players[i].bones[line[1]][0], players[i].bones[line[1]][1]),
 									skelColor, v.skeleton_thickness);
 							}
+
+							// Draw head circle
+							float headRadius = players[i].height / 12.0f;
+							ImGui::GetWindowDrawList()->AddCircle(ImVec2(players[i].bones[0][0], players[i].bones[0][1]), headRadius, skelColor, 0, v.skeleton_thickness);
+							// Connection Neck -> Head
+							DrawLine(ImVec2(players[i].bones[1][0], players[i].bones[1][1]),
+								ImVec2(players[i].bones[0][0], players[i].bones[0][1]),
+								skelColor, v.skeleton_thickness);
 						}
 					}
 


### PR DESCRIPTION
This PR enhances the Skeleton ESP by adding a circle representing the player's head and improving the overall skeleton structure.

Key changes:
1.  **Data Structure Update:** Modified the `player` struct in `apex_guest/Client/Client/main.cpp` and `apex_dma/apex_dma.cpp` to increase the `bones` array size from 15 to 17.
2.  **Host-side Bone Tracking:** Updated the host-side ESP loop in `apex_dma/apex_dma.cpp` to populate the new bone slots using corrected Apex Legends hitbox IDs (Head: 0, Neck: 1, etc.).
3.  **Enhanced Rendering:** 
    - Updated the skeleton connection lines to include a complete spine and proper limb attachments.
    - Added a head circle rendering centered at the head bone, with a radius dynamically scaled by the target's visual height.
    - Ensured rendering logic is executed outside the validation loop to maintain optimal performance.
4.  **Fixes:** Resolved a linker error caused by multiple definitions of the global `bone` variable by correctly using `extern` in `Game.cpp`.

These changes provide a more accurate and visually informative skeleton overlay for users.

---
*PR created automatically by Jules for task [13809457262105984124](https://jules.google.com/task/13809457262105984124) started by @albatror*