### PR TITLE
PML4 Scanner and EAC-aware CR3 Bypass

### DIFF
--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -1749,12 +1749,17 @@ int main(int argc, char *argv[])
 				stuff_t = false;
 				g_Base = 0;
 
-				aimbot_thr.~thread();
-				esp_thr.~thread();
-				actions_thr.~thread();
-				itemglow_thr.~thread();
-				stuffbot_thr.~thread();
+				if (aimbot_thr.joinable()) aimbot_thr.detach();
+				if (esp_thr.joinable()) esp_thr.detach();
+				if (actions_thr.joinable()) actions_thr.detach();
+				if (itemglow_thr.joinable()) itemglow_thr.detach();
+				if (stuffbot_thr.joinable()) stuffbot_thr.detach();
 
+				aimbot_thr = std::thread();
+				esp_thr = std::thread();
+				actions_thr = std::thread();
+				itemglow_thr = std::thread();
+				stuffbot_thr = std::thread();
 			}
 
 			std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -1801,7 +1806,8 @@ int main(int argc, char *argv[])
 				vars_t = false;
 				c_Base = 0;
 
-				vars_thr.~thread();
+				if (vars_thr.joinable()) vars_thr.detach();
+				vars_thr = std::thread();
 			}
 			
 			std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/apex_dma/memory.cpp
+++ b/apex_dma/memory.cpp
@@ -105,10 +105,12 @@ bool kernel_init(Inventory *inv, const char *connector_name)
 
 bool Memory::testDtbValue(const uint64_t &dtb_val)
 {
+	if (proc.baseaddr == 0) return false;
+
 	uint64_t phys_base = TranslateVirtualToPhysical(dtb_val, proc.baseaddr);
 	if (phys_base == 0) return false;
 
-	short c;
+	short c = 0;
 	if (!ReadPhysical(phys_base, &c, sizeof(c))) return false;
 
 	if (c == 0x5A4D)
@@ -126,22 +128,11 @@ bool Memory::ReadPhysical(uint64_t address, void* buffer, size_t len)
 {
 	if (!conn) return false;
 
-	PhysicalReadData data;
-	data._0.address = address;
-	data._0.page_type = PageType_UNKNOWN;
-	data._0.page_size_log2 = 0;
-	data._1 = Address_INVALID;
-	data._2.data = (uint8_t*)buffer;
-	data._2.len = len;
+	CSliceMut<uint8_t> slice;
+	slice.data = (uint8_t*)buffer;
+	slice.len = len;
 
-	std::vector<PhysicalReadData> vec = {data};
-	CPPIterator<std::vector<PhysicalReadData>> iter(vec);
-	PhysicalReadMemOps ops;
-	ops.inp = iter;
-	ops.out = nullptr;
-	ops.out_fail = nullptr;
-
-	return conn.get()->phys_read_raw_iter(ops) == 0;
+	return conn.get()->phys_view().read_raw_into(address, slice) == 0;
 }
 
 uint64_t Memory::scanPml4()
@@ -355,15 +346,29 @@ void Memory::open_proc(const char *name)
 	}
 
 
+	ProcessInfo info;
+	info.dtb2 = Address_INVALID;
+
+	if (kernel.get()->process_info_by_name(name, &info))
+	{
+		status = process_status::NOT_FOUND;
+		return;
+	}
+
+	auto base_section = std::make_unique<char[]>(8);
+	uint64_t *base_section_value = (uint64_t *)base_section.get();
+	CSliceMut<uint8_t> slice(base_section.get(), 8);
+	uint32_t EPROCESS_SectionBaseAddress_off = 0x520; // win10 >= 20H1
+	kernel.get()->read_raw_into(info.address + EPROCESS_SectionBaseAddress_off, slice);
+	proc.baseaddr = *base_section_value;
+
 	if (lastCorrectDtbPhysicalAddress && testDtbValue(lastCorrectDtbPhysicalAddress))
 	{
 		return;
 	}
 	close_proc();
 
-	ProcessInfo info;
-	info.dtb2 = Address_INVALID;
-
+	// Re-fetch info as close_proc might have invalidated things
 	if (kernel.get()->process_info_by_name(name, &info))
 	{
 		status = process_status::NOT_FOUND;
@@ -383,14 +388,6 @@ void Memory::open_proc(const char *name)
 	{
 		// Fallback for when we can't find module by name (likely due to shuffled/invalid CR3)
 		status = process_status::FOUND_NO_ACCESS;
-		auto base_section = std::make_unique<char[]>(8);
-		uint64_t *base_section_value = (uint64_t *)base_section.get();
-		CSliceMut<uint8_t> slice(base_section.get(), 8);
-		uint32_t EPROCESS_SectionBaseAddress_off = 0x520; // win10 >= 20H1
-
-		// Attempt to read SectionBaseAddress from EPROCESS to get baseaddr
-		kernel.get()->read_raw_into(info.address + EPROCESS_SectionBaseAddress_off, slice);
-		proc.baseaddr = *base_section_value;
 
 		uint64_t found_dtb = scanPml4();
 		if (found_dtb)
@@ -416,7 +413,7 @@ void Memory::open_proc(const char *name)
 void Memory::close_proc()
 {
 	std::lock_guard<std::mutex> l(m);
-	proc.hProcess.~IntoProcessInstance();
+	proc.hProcess = IntoProcessInstance<>();
 	lastCorrectDtbPhysicalAddress = 0;
 	proc.baseaddr = 0;
 }

--- a/apex_dma/memory.cpp
+++ b/apex_dma/memory.cpp
@@ -2,7 +2,7 @@
 #include <unistd.h>
 #include <vector>
 
-static std::mutex static_m;
+static std::recursive_mutex static_m;
 
 // Credits: learn_more, stevemk14ebr
 size_t findPattern(const PBYTE rangeStart, size_t len, const char *pattern)
@@ -83,7 +83,7 @@ void Memory::check_proc()
 
 bool kernel_init(Inventory *inv, const char *connector_name)
 {
-	std::lock_guard<std::mutex> l(static_m);
+	std::lock_guard<std::recursive_mutex> l(static_m);
 	if (mf_inventory_create_connector(inv, connector_name, "", conn.get()))
 	{
 		printf("Can't create %s connector\n", connector_name);
@@ -109,6 +109,10 @@ bool kernel_init(Inventory *inv, const char *connector_name)
 		return false;
 	}
 
+	// mf_inventory_create_os MOVED the cloned_conn. We must forget its container locally to avoid double-drop
+	// when 'cloned_conn' goes out of scope and its destructor is called.
+	mem_forget(cloned_conn.container);
+
 	return true;
 }
 
@@ -133,7 +137,7 @@ bool Memory::testDtbValue(const uint64_t &dtb_val)
 
 bool Memory::ReadPhysical(uint64_t address, void* buffer, size_t len)
 {
-	std::lock_guard<std::mutex> l(static_m);
+	std::lock_guard<std::recursive_mutex> l(static_m);
 	if (!conn || !conn.get()->vtbl_physicalmemory) return false;
 
 	CSliceMut<uint8_t> slice;
@@ -245,6 +249,8 @@ uint64_t Memory::TranslateVirtualToPhysical(uint64_t dtb, uint64_t virtualAddr)
 	uint64_t pd = (virtualAddr >> 30) & 0x1ff;
 	uint64_t pdp = (virtualAddr >> 39) & 0x1ff;
 
+	const uint64_t PMASK = 0x000FFFFFFFFFF000;
+
 	uint64_t pml4e_addr = dtb + 8 * pdp;
 	uint64_t pml4e = 0;
 	if (!ReadPhysical(pml4e_addr, &pml4e, sizeof(pml4e))) return 0;
@@ -254,25 +260,25 @@ uint64_t Memory::TranslateVirtualToPhysical(uint64_t dtb, uint64_t virtualAddr)
 
 	if (!(pml4e & 1)) return 0;
 
-	uint64_t pdpe_addr = (pml4e & 0xFFFFFFFFF000) + 8 * pd;
+	uint64_t pdpe_addr = (pml4e & PMASK) + 8 * pd;
 	uint64_t pdpe = 0;
 	if (!ReadPhysical(pdpe_addr, &pdpe, sizeof(pdpe)) || !(pdpe & 1)) return 0;
 
 	// 1GB Large Page
-	if (pdpe & 0x80) return (pdpe & 0xFFFFFC000000) + (virtualAddr & 0x3FFFFFFF);
+	if (pdpe & 0x80) return (pdpe & 0x000FFFFFC0000000) + (virtualAddr & 0x3FFFFFFF);
 
-	uint64_t pde_addr = (pdpe & 0xFFFFFFFFF000) + 8 * pt;
+	uint64_t pde_addr = (pdpe & PMASK) + 8 * pt;
 	uint64_t pde = 0;
 	if (!ReadPhysical(pde_addr, &pde, sizeof(pde)) || !(pde & 1)) return 0;
 
 	// 2MB Large Page
-	if (pde & 0x80) return (pde & 0xFFFFFFE00000) + (virtualAddr & 0x1FFFFF);
+	if (pde & 0x80) return (pde & 0x000FFFFFFFE00000) + (virtualAddr & 0x1FFFFF);
 
-	uint64_t pte_addr = (pde & 0xFFFFFFFFF000) + 8 * pte;
+	uint64_t pte_addr = (pde & PMASK) + 8 * pte;
 	uint64_t pte_val = 0;
 	if (!ReadPhysical(pte_addr, &pte_val, sizeof(pte_val)) || !(pte_val & 1)) return 0;
 
-	return (pte_val & 0xFFFFFFFFF000) + pageOffset;
+	return (pte_val & PMASK) + pageOffset;
 }
 
 // https://www.unknowncheats.me/forum/apex-legends/670570-quick-obtain-cr3-check.html
@@ -334,7 +340,7 @@ void Memory::open_proc(const char *name)
 {
 	std::lock_guard<std::mutex> l(m);
 	{
-		std::lock_guard<std::mutex> sl(static_m);
+		std::lock_guard<std::recursive_mutex> sl(static_m);
 		if (!conn)
 		{
 			conn = std::make_unique<ConnectorInstance<>>();
@@ -359,10 +365,14 @@ void Memory::open_proc(const char *name)
 
 
 	ProcessInfo info;
-	info.name = nullptr;
-	info.path = nullptr;
-	info.command_line = nullptr;
+	memset(&info, 0, sizeof(info));
 	info.dtb2 = Address_INVALID;
+
+	if (!kernel || !kernel.get()->vtbl_os)
+	{
+		status = process_status::NOT_FOUND;
+		return;
+	}
 
 	if (kernel.get()->process_info_by_name(name, &info))
 	{
@@ -372,10 +382,19 @@ void Memory::open_proc(const char *name)
 
 	auto base_section = std::make_unique<char[]>(8);
 	uint64_t *base_section_value = (uint64_t *)base_section.get();
-	CSliceMut<uint8_t> slice(base_section.get(), 8);
+	CSliceMut<uint8_t> slice;
+	slice.data = (uint8_t*)base_section.get();
+	slice.len = 8;
+
 	uint32_t EPROCESS_SectionBaseAddress_off = 0x520; // win10 >= 20H1
-	kernel.get()->read_raw_into(info.address + EPROCESS_SectionBaseAddress_off, slice);
-	proc.baseaddr = *base_section_value;
+	if (info.address != 0 && kernel.get()->read_raw_into(info.address + EPROCESS_SectionBaseAddress_off, slice) == 0)
+	{
+		proc.baseaddr = *base_section_value;
+	}
+	else
+	{
+		proc.baseaddr = 0;
+	}
 
 	if (lastCorrectDtbPhysicalAddress && testDtbValue(lastCorrectDtbPhysicalAddress))
 	{

--- a/apex_dma/memory.cpp
+++ b/apex_dma/memory.cpp
@@ -1,6 +1,7 @@
 #include "memory.h"
 #include <unistd.h>
 #include <vector>
+#include <cstring>
 
 static std::recursive_mutex static_m;
 
@@ -84,7 +85,9 @@ void Memory::check_proc()
 bool kernel_init(Inventory *inv, const char *connector_name)
 {
 	std::lock_guard<std::recursive_mutex> l(static_m);
-	if (mf_inventory_create_connector(inv, connector_name, "", conn.get()))
+
+	ConnectorInstance<> temp_conn;
+	if (mf_inventory_create_connector(inv, connector_name, "", &temp_conn))
 	{
 		printf("Can't create %s connector\n", connector_name);
 		return false;
@@ -94,24 +97,25 @@ bool kernel_init(Inventory *inv, const char *connector_name)
 		printf("%s connector created\n", connector_name);
 	}
 
-	// Important: mf_inventory_create_os MOVES the connector, zeroing its vtables.
-	// We must clone it so the global 'conn' remains valid for physical reads.
-	ConnectorInstance<> cloned_conn;
-	mf_connector_clone(conn.get(), &cloned_conn);
+	// Clone the temporary connector into our static global 'conn'
+	conn = std::make_unique<ConnectorInstance<>>();
+	mf_connector_clone(&temp_conn, conn.get());
 
 	kernel = std::make_unique<OsInstance<>>();
-	if (mf_inventory_create_os(inv, "win32", "", &cloned_conn, kernel.get()))
+	// Important: mf_inventory_create_os MOVES the temp_conn, zeroing its vtables.
+	if (mf_inventory_create_os(inv, "win32", "", &temp_conn, kernel.get()))
 	{
 		printf("Unable to initialize kernel using %s connector\n", connector_name);
-		mf_connector_drop(&cloned_conn);
+		mf_connector_drop(&temp_conn);
 		mf_connector_drop(conn.get());
 		kernel.reset();
+		conn.reset();
 		return false;
 	}
 
-	// mf_inventory_create_os MOVED the cloned_conn. We must forget its container locally to avoid double-drop
-	// when 'cloned_conn' goes out of scope and its destructor is called.
-	mem_forget(cloned_conn.container);
+	// mf_inventory_create_os MOVED the temp_conn. We must forget its container locally to avoid double-drop
+	// when 'temp_conn' goes out of scope and its destructor is called.
+	mem_forget(temp_conn.container);
 
 	return true;
 }
@@ -140,6 +144,8 @@ bool Memory::ReadPhysical(uint64_t address, void* buffer, size_t len)
 	std::lock_guard<std::recursive_mutex> l(static_m);
 	if (!conn || !conn.get()->vtbl_physicalmemory) return false;
 
+	if (address + len > MAX_PHYADDR) return false;
+
 	CSliceMut<uint8_t> slice;
 	slice.data = (uint8_t*)buffer;
 	slice.len = len;
@@ -167,19 +173,24 @@ uint64_t Memory::scanPml4()
 		return 0;
 	}
 
-	// PML4 entries 256-511 are kernel space and must be an EXACT match across all processes
+	// PML4 entries 256-511 are kernel space and must be a near-exact match across all processes
 	// using PID 4 (System) as the ground truth.
 	uint64_t signature[256];
 	int signature_entries = 0;
+	int first_entry_idx = -1;
 	for (int i = 256; i < 512; i++)
 	{
 		signature[i - 256] = system_pml4[i];
-		if (system_pml4[i] != 0) signature_entries++;
+		if (system_pml4[i] != 0)
+		{
+			signature_entries++;
+			if (first_entry_idx == -1) first_entry_idx = i - 256;
+		}
 	}
 
-	if (signature_entries < 5) return 0; // Sanity check
+	if (signature_entries < 3 || first_entry_idx == -1) return 0; // Sanity check
 
-	printf("[*] Scanning physical memory for PML4 signature (%d entries)...\n", signature_entries);
+	printf("[*] Scanning physical memory for PML4 signature (%d entries, first at index %d)...\n", signature_entries, 256 + first_entry_idx);
 	auto start = std::chrono::high_resolution_clock::now();
 
 	// Scan physical memory in 2MB chunks for efficiency
@@ -192,6 +203,8 @@ uint64_t Memory::scanPml4()
 	uint64_t search_limit = 0x800000000; // 32GB
 	if (search_limit > MAX_PHYADDR) search_limit = MAX_PHYADDR;
 
+	const uint64_t MASK = 0x000FFFFFFFFFF001; // PFN + Present bit
+
 	for (uint64_t addr = 0; addr < search_limit; addr += scan_size)
 	{
 		if (!ReadPhysical(addr, buffer, scan_size)) continue;
@@ -200,20 +213,20 @@ uint64_t Memory::scanPml4()
 		{
 			uint64_t* candidate_pml4 = (uint64_t*)(buffer + offset);
 
-			// Quick check: first kernel entry should match
-			if (candidate_pml4[256] != signature[0]) continue;
+			// Quick check: first non-zero kernel entry should match (masking volatile flags)
+			if ((candidate_pml4[256 + first_entry_idx] & MASK) != (signature[first_entry_idx] & MASK)) continue;
 
-			bool match = true;
-			for (int i = 257; i < 512; i++)
+			int current_matches = 0;
+			for (int i = 256; i < 512; i++)
 			{
-				if (candidate_pml4[i] != signature[i - 256])
+				if (signature[i - 256] == 0) continue;
+				if ((candidate_pml4[i] & MASK) == (signature[i - 256] & MASK))
 				{
-					match = false;
-					break;
+					current_matches++;
 				}
 			}
 
-			if (match)
+			if (current_matches >= (signature_entries - 1))
 			{
 				uint64_t candidate_dtb = addr + offset;
 				if (testDtbValue(candidate_dtb))
@@ -338,20 +351,19 @@ bool Memory::bruteforceDtb(uint64_t dtbStartPhysicalAddr, const uint64_t stepPag
 
 void Memory::open_proc(const char *name)
 {
-	std::lock_guard<std::mutex> l(m);
+	std::lock_guard<std::recursive_mutex> l(static_m);
+	if (!conn)
 	{
-		std::lock_guard<std::recursive_mutex> sl(static_m);
-		if (!conn)
-		{
-			conn = std::make_unique<ConnectorInstance<>>();
+		printf("[*] Opening connector...\n");
+		conn = std::make_unique<ConnectorInstance<>>();
 		Inventory *inv = mf_inventory_scan();
 		mf_inventory_add_dir(inv, ".");
 
 		printf("Init with kvm connector...\n");
 		if (!kernel_init(inv, "kvm"))
 		{
-		printf("Init with qemu connector...\n");
-		if (!kernel_init(inv, "qemu"))
+			printf("[*] KVM failed, trying QEMU...\n");
+			if (!kernel_init(inv, "qemu"))
 			{
 				printf("Quitting\n");
 				mf_inventory_free(inv);
@@ -359,8 +371,7 @@ void Memory::open_proc(const char *name)
 			}
 		}
 
-			printf("Kernel initialized: %p\n", kernel.get()->container.instance.instance);
-		}
+		printf("Kernel initialized: %p\n", kernel.get()->container.instance.instance);
 	}
 
 
@@ -376,6 +387,7 @@ void Memory::open_proc(const char *name)
 
 	if (kernel.get()->process_info_by_name(name, &info))
 	{
+		printf("[-] Process %s not found\n", name);
 		status = process_status::NOT_FOUND;
 		return;
 	}
@@ -387,7 +399,7 @@ void Memory::open_proc(const char *name)
 	slice.len = 8;
 
 	uint32_t EPROCESS_SectionBaseAddress_off = 0x520; // win10 >= 20H1
-	if (info.address != 0 && kernel.get()->read_raw_into(info.address + EPROCESS_SectionBaseAddress_off, slice) == 0)
+	if (info.address != 0 && kernel && kernel.get()->vtbl_memoryview && kernel.get()->read_raw_into(info.address + EPROCESS_SectionBaseAddress_off, slice) == 0)
 	{
 		proc.baseaddr = *base_section_value;
 	}
@@ -398,6 +410,7 @@ void Memory::open_proc(const char *name)
 
 	if (lastCorrectDtbPhysicalAddress && testDtbValue(lastCorrectDtbPhysicalAddress))
 	{
+		printf("[+] Using last correct DTB: 0x%lx\n", lastCorrectDtbPhysicalAddress);
 		info.dtb1 = lastCorrectDtbPhysicalAddress;
 		if (kernel.get()->clone().into_process_by_info(info, &proc.hProcess) == 0)
 		{
@@ -437,7 +450,7 @@ void Memory::open_proc(const char *name)
 
 void Memory::close_proc()
 {
-	std::lock_guard<std::mutex> l(m);
+	std::lock_guard<std::recursive_mutex> l(static_m);
 	proc.baseaddr = 0;
 	lastCorrectDtbPhysicalAddress = 0;
 	status = process_status::NOT_FOUND;

--- a/apex_dma/memory.cpp
+++ b/apex_dma/memory.cpp
@@ -199,19 +199,32 @@ uint64_t Memory::scanPml4()
 	if (!buffer) return 0;
 
 	uint64_t found_dtb = 0;
-	// Only scan up to a reasonable physical limit to avoid hangs (e.g., 32GB)
-	uint64_t search_limit = 0x800000000; // 32GB
+	// Use 64GB as the limit for modern systems with high RAM or memory holes
+	uint64_t search_limit = 0x1000000000; // 64GB
 	if (search_limit > MAX_PHYADDR) search_limit = MAX_PHYADDR;
 
 	const uint64_t MASK = 0x000FFFFFFFFFF001; // PFN + Present bit
 
 	for (uint64_t addr = 0; addr < search_limit; addr += scan_size)
 	{
-		if (!ReadPhysical(addr, buffer, scan_size)) continue;
+		bool block_read_success = ReadPhysical(addr, buffer, scan_size);
 
 		for (size_t offset = 0; offset < scan_size; offset += 0x1000)
 		{
-			uint64_t* candidate_pml4 = (uint64_t*)(buffer + offset);
+			uint64_t candidate_dtb = addr + offset;
+			uint64_t* candidate_pml4;
+			uint64_t local_page[512];
+
+			if (block_read_success)
+			{
+				candidate_pml4 = (uint64_t*)(buffer + offset);
+			}
+			else
+			{
+				// Block read failed, likely due to a gap. Try reading just this page.
+				if (!ReadPhysical(candidate_dtb, local_page, sizeof(local_page))) continue;
+				candidate_pml4 = local_page;
+			}
 
 			// Quick check: first non-zero kernel entry should match (masking volatile flags)
 			if ((candidate_pml4[256 + first_entry_idx] & MASK) != (signature[first_entry_idx] & MASK)) continue;
@@ -226,9 +239,9 @@ uint64_t Memory::scanPml4()
 				}
 			}
 
-			if (current_matches >= (signature_entries - 1))
+			// Require at least 90% match for robustness
+			if (current_matches >= (signature_entries * 9 / 10))
 			{
-				uint64_t candidate_dtb = addr + offset;
 				if (testDtbValue(candidate_dtb))
 				{
 					found_dtb = candidate_dtb;
@@ -294,60 +307,6 @@ uint64_t Memory::TranslateVirtualToPhysical(uint64_t dtb, uint64_t virtualAddr)
 	return (pte_val & PMASK) + pageOffset;
 }
 
-// https://www.unknowncheats.me/forum/apex-legends/670570-quick-obtain-cr3-check.html
-bool Memory::bruteforceDtb(uint64_t dtbStartPhysicalAddr, const uint64_t stepPage)
-{
-	// eac cr3 always end with 0x-----XX000
-	// dtbStartPhysicalAddr should be a multiple of 0x1000
-	if ((dtbStartPhysicalAddr & 0xFFF) != 0)
-		return false;
-	if (dtbStartPhysicalAddr > MAX_PHYADDR)
-		return false;
-
-	dtbStartPhysicalAddr -= dtbStartPhysicalAddr % stepPage;
-	dtbStartPhysicalAddr += lastCorrectDtbPhysicalAddress % stepPage;
-
-	auto start = std::chrono::high_resolution_clock::now();
-	bool result = false;
-	uint64_t furtherDistance = GetFurtherDistance(dtbStartPhysicalAddr, 0x0, MAX_PHYADDR);
-	size_t maxStep = furtherDistance / stepPage;
-	uint64_t guessDtbAddr = 0;
-
-	for (size_t step = 0; step < maxStep; step++)
-	{
-		// bruteforce dtb from middle
-		guessDtbAddr = dtbStartPhysicalAddr + step * stepPage;
-		if (guessDtbAddr < MAX_PHYADDR)
-		{
-			if (testDtbValue(guessDtbAddr))
-			{
-				result = true;
-				break;
-			}
-		}
-		// dont forget the other side
-		if (dtbStartPhysicalAddr > step * stepPage)
-		{
-			guessDtbAddr = dtbStartPhysicalAddr - step * stepPage;
-			if (testDtbValue(guessDtbAddr))
-			{
-				result = true;
-				break;
-			}
-		}
-	}
-
-	auto end = std::chrono::high_resolution_clock::now();
-	auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-	printf("[+] bruteforce dtb %s to find dtb:0x%lx, time:%ldms\n", result ? "success" : "failed", result ? guessDtbAddr : 0x0, duration.count());
-
-	// In case we cannot get the dtb through this shortcut method.
-	if (result == false && stepPage != 0x1000)
-	{
-		return bruteforceDtb(dtbStartPhysicalAddr, 0x1000);
-	}
-	return result;
-}
 
 void Memory::open_proc(const char *name)
 {

--- a/apex_dma/memory.cpp
+++ b/apex_dma/memory.cpp
@@ -2,6 +2,8 @@
 #include <unistd.h>
 #include <vector>
 
+static std::mutex static_m;
+
 // Credits: learn_more, stevemk14ebr
 size_t findPattern(const PBYTE rangeStart, size_t len, const char *pattern)
 {
@@ -81,6 +83,7 @@ void Memory::check_proc()
 
 bool kernel_init(Inventory *inv, const char *connector_name)
 {
+	std::lock_guard<std::mutex> l(static_m);
 	if (mf_inventory_create_connector(inv, connector_name, "", conn.get()))
 	{
 		printf("Can't create %s connector\n", connector_name);
@@ -91,10 +94,16 @@ bool kernel_init(Inventory *inv, const char *connector_name)
 		printf("%s connector created\n", connector_name);
 	}
 
+	// Important: mf_inventory_create_os MOVES the connector, zeroing its vtables.
+	// We must clone it so the global 'conn' remains valid for physical reads.
+	ConnectorInstance<> cloned_conn;
+	mf_connector_clone(conn.get(), &cloned_conn);
+
 	kernel = std::make_unique<OsInstance<>>();
-	if (mf_inventory_create_os(inv, "win32", "", conn.get(), kernel.get()))
+	if (mf_inventory_create_os(inv, "win32", "", &cloned_conn, kernel.get()))
 	{
 		printf("Unable to initialize kernel using %s connector\n", connector_name);
+		mf_connector_drop(&cloned_conn);
 		mf_connector_drop(conn.get());
 		kernel.reset();
 		return false;
@@ -124,7 +133,8 @@ bool Memory::testDtbValue(const uint64_t &dtb_val)
 
 bool Memory::ReadPhysical(uint64_t address, void* buffer, size_t len)
 {
-	if (!conn) return false;
+	std::lock_guard<std::mutex> l(static_m);
+	if (!conn || !conn.get()->vtbl_physicalmemory) return false;
 
 	CSliceMut<uint8_t> slice;
 	slice.data = (uint8_t*)buffer;
@@ -323,9 +333,11 @@ bool Memory::bruteforceDtb(uint64_t dtbStartPhysicalAddr, const uint64_t stepPag
 void Memory::open_proc(const char *name)
 {
 	std::lock_guard<std::mutex> l(m);
-	if (!conn)
 	{
-		conn = std::make_unique<ConnectorInstance<>>();
+		std::lock_guard<std::mutex> sl(static_m);
+		if (!conn)
+		{
+			conn = std::make_unique<ConnectorInstance<>>();
 		Inventory *inv = mf_inventory_scan();
 		mf_inventory_add_dir(inv, ".");
 
@@ -341,11 +353,15 @@ void Memory::open_proc(const char *name)
 			}
 		}
 
-		printf("Kernel initialized: %p\n", kernel.get()->container.instance.instance);
+			printf("Kernel initialized: %p\n", kernel.get()->container.instance.instance);
+		}
 	}
 
 
 	ProcessInfo info;
+	info.name = nullptr;
+	info.path = nullptr;
+	info.command_line = nullptr;
 	info.dtb2 = Address_INVALID;
 
 	if (kernel.get()->process_info_by_name(name, &info))

--- a/apex_dma/memory.cpp
+++ b/apex_dma/memory.cpp
@@ -1,5 +1,6 @@
 #include "memory.h"
 #include <unistd.h>
+#include <vector>
 
 // Credits: learn_more, stevemk14ebr
 size_t findPattern(const PBYTE rangeStart, size_t len, const char *pattern)
@@ -104,15 +105,175 @@ bool kernel_init(Inventory *inv, const char *connector_name)
 
 bool Memory::testDtbValue(const uint64_t &dtb_val)
 {
-	proc.hProcess.set_dtb(dtb_val, Address_INVALID);
-	check_proc();
-	if (status == process_status::FOUND_READY)
+	uint64_t phys_base = TranslateVirtualToPhysical(dtb_val, proc.baseaddr);
+	if (phys_base == 0) return false;
+
+	short c;
+	if (!ReadPhysical(phys_base, &c, sizeof(c))) return false;
+
+	if (c == 0x5A4D)
 	{
+		proc.hProcess.set_dtb(dtb_val, Address_INVALID);
 		lastCorrectDtbPhysicalAddress = dtb_val;
+		status = process_status::FOUND_READY;
 		return true;
 	}
 
 	return false;
+}
+
+bool Memory::ReadPhysical(uint64_t address, void* buffer, size_t len)
+{
+	if (!conn) return false;
+
+	PhysicalReadData data;
+	data._0.address = address;
+	data._0.page_type = PageType_UNKNOWN;
+	data._0.page_size_log2 = 0;
+	data._1 = Address_INVALID;
+	data._2.data = (uint8_t*)buffer;
+	data._2.len = len;
+
+	std::vector<PhysicalReadData> vec = {data};
+	CPPIterator<std::vector<PhysicalReadData>> iter(vec);
+	PhysicalReadMemOps ops;
+	ops.inp = iter;
+	ops.out = nullptr;
+	ops.out_fail = nullptr;
+
+	return conn.get()->phys_read_raw_iter(ops) == 0;
+}
+
+uint64_t Memory::scanPml4()
+{
+	if (!kernel || !conn) return 0;
+
+	// Reset status for scanning
+	status = process_status::NOT_FOUND;
+
+	ProcessInfo system_info;
+	if (kernel.get()->process_info_by_pid(4, &system_info))
+	{
+		return 0;
+	}
+
+	uint64_t system_dtb = system_info.dtb1;
+	uint64_t system_pml4[512];
+	if (!ReadPhysical(system_dtb, system_pml4, sizeof(system_pml4)))
+	{
+		return 0;
+	}
+
+	// PML4 entries 256-511 are kernel space and must be an EXACT match across all processes
+	// using PID 4 (System) as the ground truth.
+	uint64_t signature[256];
+	int signature_entries = 0;
+	for (int i = 256; i < 512; i++)
+	{
+		signature[i - 256] = system_pml4[i];
+		if (system_pml4[i] != 0) signature_entries++;
+	}
+
+	if (signature_entries < 5) return 0; // Sanity check
+
+	printf("[*] Scanning physical memory for PML4 signature (%d entries)...\n", signature_entries);
+	auto start = std::chrono::high_resolution_clock::now();
+
+	// Scan physical memory in 2MB chunks for efficiency
+	const size_t scan_size = 2 * 1024 * 1024;
+	uint8_t* buffer = (uint8_t*)malloc(scan_size);
+	if (!buffer) return 0;
+
+	uint64_t found_dtb = 0;
+	// Only scan up to a reasonable physical limit to avoid hangs (e.g., 32GB)
+	uint64_t search_limit = 0x800000000; // 32GB
+	if (search_limit > MAX_PHYADDR) search_limit = MAX_PHYADDR;
+
+	for (uint64_t addr = 0; addr < search_limit; addr += scan_size)
+	{
+		if (!ReadPhysical(addr, buffer, scan_size)) continue;
+
+		for (size_t offset = 0; offset < scan_size; offset += 0x1000)
+		{
+			uint64_t* candidate_pml4 = (uint64_t*)(buffer + offset);
+
+			// Quick check: first kernel entry should match
+			if (candidate_pml4[256] != signature[0]) continue;
+
+			bool match = true;
+			for (int i = 257; i < 512; i++)
+			{
+				if (candidate_pml4[i] != signature[i - 256])
+				{
+					match = false;
+					break;
+				}
+			}
+
+			if (match)
+			{
+				uint64_t candidate_dtb = addr + offset;
+				if (testDtbValue(candidate_dtb))
+				{
+					found_dtb = candidate_dtb;
+					goto end;
+				}
+			}
+		}
+	}
+
+end:
+	free(buffer);
+	auto end_time = std::chrono::high_resolution_clock::now();
+	auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start);
+	printf("[+] PML4 scan %s, found DTB: 0x%lx, time: %ldms\n", found_dtb ? "success" : "failed", found_dtb, duration.count());
+	return found_dtb;
+}
+
+bool Memory::IsMovedByEAC(uint64_t pml4eAddr, uint64_t pml4eContent)
+{
+	// From UnknownCheats: https://www.unknowncheats.me/forum/4243560-post1.html
+	return (pml4eAddr & 0xff0000) == (pml4eContent & 0xff0000) && ((pml4eContent >> 48) & 0xffff) == 0;
+}
+
+uint64_t Memory::TranslateVirtualToPhysical(uint64_t dtb, uint64_t virtualAddr)
+{
+	dtb &= ~0xf;
+
+	uint64_t pageOffset = virtualAddr & 0xFFF;
+	uint64_t pte = (virtualAddr >> 12) & 0x1ff;
+	uint64_t pt = (virtualAddr >> 21) & 0x1ff;
+	uint64_t pd = (virtualAddr >> 30) & 0x1ff;
+	uint64_t pdp = (virtualAddr >> 39) & 0x1ff;
+
+	uint64_t pml4e_addr = dtb + 8 * pdp;
+	uint64_t pml4e = 0;
+	if (!ReadPhysical(pml4e_addr, &pml4e, sizeof(pml4e))) return 0;
+
+	// Shadow CR3 Check from UnknownCheats
+	if (IsMovedByEAC(pml4e_addr, pml4e)) return 0;
+
+	if (!(pml4e & 1)) return 0;
+
+	uint64_t pdpe_addr = (pml4e & 0xFFFFFFFFF000) + 8 * pd;
+	uint64_t pdpe = 0;
+	if (!ReadPhysical(pdpe_addr, &pdpe, sizeof(pdpe)) || !(pdpe & 1)) return 0;
+
+	// 1GB Large Page
+	if (pdpe & 0x80) return (pdpe & 0xFFFFFC000000) + (virtualAddr & 0x3FFFFFFF);
+
+	uint64_t pde_addr = (pdpe & 0xFFFFFFFFF000) + 8 * pt;
+	uint64_t pde = 0;
+	if (!ReadPhysical(pde_addr, &pde, sizeof(pde)) || !(pde & 1)) return 0;
+
+	// 2MB Large Page
+	if (pde & 0x80) return (pde & 0xFFFFFFE00000) + (virtualAddr & 0x1FFFFF);
+
+	uint64_t pte_addr = (pde & 0xFFFFFFFFF000) + 8 * pte;
+	uint64_t pte_val = 0;
+	if (!ReadPhysical(pte_addr, &pte_val, sizeof(pte_val)) || !(pte_val & 1)) return 0;
+
+	return (pte_val & 0xFFFFFFFFF000) + pageOffset;
 }
 
 // https://www.unknowncheats.me/forum/apex-legends/670570-quick-obtain-cr3-check.html
@@ -194,7 +355,7 @@ void Memory::open_proc(const char *name)
 	}
 
 
-	if (lastCorrectDtbPhysicalAddress && bruteforceDtb(0x0, 0x100000))
+	if (lastCorrectDtbPhysicalAddress && testDtbValue(lastCorrectDtbPhysicalAddress))
 	{
 		return;
 	}
@@ -206,11 +367,8 @@ void Memory::open_proc(const char *name)
 	if (kernel.get()->process_info_by_name(name, &info))
 	{
 		status = process_status::NOT_FOUND;
-		//lastCorrectDtbPhysicalAddress = 0;
 		return;
 	}
-	//
-	//close_proc();
 
 	if (kernel.get()->clone().into_process_by_info(info, &proc.hProcess))
 	{
@@ -223,15 +381,25 @@ void Memory::open_proc(const char *name)
 	ModuleInfo module_info;
 	if (proc.hProcess.module_by_name(name, &module_info))
 	{
+		// Fallback for when we can't find module by name (likely due to shuffled/invalid CR3)
 		status = process_status::FOUND_NO_ACCESS;
 		auto base_section = std::make_unique<char[]>(8);
 		uint64_t *base_section_value = (uint64_t *)base_section.get();
 		CSliceMut<uint8_t> slice(base_section.get(), 8);
 		uint32_t EPROCESS_SectionBaseAddress_off = 0x520; // win10 >= 20H1
+
+		// Attempt to read SectionBaseAddress from EPROCESS to get baseaddr
 		kernel.get()->read_raw_into(info.address + EPROCESS_SectionBaseAddress_off, slice);
 		proc.baseaddr = *base_section_value;
 
-		if (!bruteforceDtb(0x0, 0x100000))
+		uint64_t found_dtb = scanPml4();
+		if (found_dtb)
+		{
+			proc.hProcess.set_dtb(found_dtb, Address_INVALID);
+			lastCorrectDtbPhysicalAddress = found_dtb;
+			status = process_status::FOUND_READY;
+		}
+		else
 		{
 			close_proc();
 			return;

--- a/apex_dma/memory.cpp
+++ b/apex_dma/memory.cpp
@@ -115,9 +115,7 @@ bool Memory::testDtbValue(const uint64_t &dtb_val)
 
 	if (c == 0x5A4D)
 	{
-		proc.hProcess.set_dtb(dtb_val, Address_INVALID);
 		lastCorrectDtbPhysicalAddress = dtb_val;
-		status = process_status::FOUND_READY;
 		return true;
 	}
 
@@ -324,6 +322,7 @@ bool Memory::bruteforceDtb(uint64_t dtbStartPhysicalAddr, const uint64_t stepPag
 
 void Memory::open_proc(const char *name)
 {
+	std::lock_guard<std::mutex> l(m);
 	if (!conn)
 	{
 		conn = std::make_unique<ConnectorInstance<>>();
@@ -364,58 +363,50 @@ void Memory::open_proc(const char *name)
 
 	if (lastCorrectDtbPhysicalAddress && testDtbValue(lastCorrectDtbPhysicalAddress))
 	{
-		return;
-	}
-	close_proc();
-
-	// Re-fetch info as close_proc might have invalidated things
-	if (kernel.get()->process_info_by_name(name, &info))
-	{
-		status = process_status::NOT_FOUND;
-		return;
-	}
-
-	if (kernel.get()->clone().into_process_by_info(info, &proc.hProcess))
-	{
-		status = process_status::FOUND_NO_ACCESS;
-		printf("Error while opening process %s\n", name);
-		close_proc();
-		return;
-	}
-
-	ModuleInfo module_info;
-	if (proc.hProcess.module_by_name(name, &module_info))
-	{
-		// Fallback for when we can't find module by name (likely due to shuffled/invalid CR3)
-		status = process_status::FOUND_NO_ACCESS;
-
-		uint64_t found_dtb = scanPml4();
-		if (found_dtb)
+		info.dtb1 = lastCorrectDtbPhysicalAddress;
+		if (kernel.get()->clone().into_process_by_info(info, &proc.hProcess) == 0)
 		{
-			proc.hProcess.set_dtb(found_dtb, Address_INVALID);
-			lastCorrectDtbPhysicalAddress = found_dtb;
 			status = process_status::FOUND_READY;
-		}
-		else
-		{
-			close_proc();
 			return;
 		}
 	}
-	else
+
+	// Try standard initialization first
+	if (kernel.get()->clone().into_process_by_info(info, &proc.hProcess) == 0)
 	{
-		proc.baseaddr = module_info.base;
+		ModuleInfo module_info;
+		if (proc.hProcess.module_by_name(name, &module_info) == 0)
+		{
+			proc.baseaddr = module_info.base;
+			status = process_status::FOUND_READY;
+			return;
+		}
 	}
 
-	status = process_status::FOUND_READY;
+	// If standard failed or module not found (EAC protection), use PML4 scanner
+	uint64_t found_dtb = scanPml4();
+	if (found_dtb)
+	{
+		info.dtb1 = found_dtb;
+		if (kernel.get()->clone().into_process_by_info(info, &proc.hProcess) == 0)
+		{
+			lastCorrectDtbPhysicalAddress = found_dtb;
+			status = process_status::FOUND_READY;
+			return;
+		}
+	}
+
+	status = process_status::FOUND_NO_ACCESS;
+	printf("Error: Unable to acquire process %s with valid DTB\n", name);
 }
 
 void Memory::close_proc()
 {
 	std::lock_guard<std::mutex> l(m);
-	proc.hProcess = IntoProcessInstance<>();
-	lastCorrectDtbPhysicalAddress = 0;
 	proc.baseaddr = 0;
+	lastCorrectDtbPhysicalAddress = 0;
+	status = process_status::NOT_FOUND;
+	proc.hProcess = IntoProcessInstance<>();
 }
 
 uint64_t Memory::ScanPointer(uint64_t ptr_address, const uint32_t offsets[], int level)

--- a/apex_dma/memory.h
+++ b/apex_dma/memory.h
@@ -92,8 +92,6 @@ public:
 
 	uint64_t ScanPointer(uint64_t ptr_address, const uint32_t offsets[], int level);
 
-	bool bruteforceDtb(uint64_t dtbStartPhysicalAddr, const uint64_t stepPage);
-
 	bool testDtbValue(const uint64_t &dtb_val);
 
 	bool ReadPhysical(uint64_t address, void* buffer, size_t len);

--- a/apex_dma/memory.h
+++ b/apex_dma/memory.h
@@ -96,6 +96,14 @@ public:
 
 	bool testDtbValue(const uint64_t &dtb_val);
 
+	bool ReadPhysical(uint64_t address, void* buffer, size_t len);
+
+	uint64_t scanPml4();
+
+	bool IsMovedByEAC(uint64_t pml4eAddr, uint64_t pml4eContent);
+
+	uint64_t TranslateVirtualToPhysical(uint64_t dtb, uint64_t virtualAddr);
+
 	bool Dump(const char *filename);
 };
 


### PR DESCRIPTION
Updated the memory management logic to bypass EAC's CR3 protection mechanisms using a PML4 scanner and a manual page table walker. 

The new PML4 scanner identifies valid Directory Table Base (DTB) candidates by matching the kernel-space portion of the PML4 table (entries 256-511) against the System process (PID 4). This approach is significantly faster and more accurate than the previous linear brute-force method.

Additionally, implemented an EAC-aware manual page table walker (`TranslateVirtualToPhysical`) that detects shuffled page tables using the `IsMovedByEAC` signature check. The process verification logic now uses this manual walker to translate the process base address and verify the presence of the "MZ" header directly in physical memory, ensuring high reliability during process initialization.

---
*PR created automatically by Jules for task [5814204465488041099](https://jules.google.com/task/5814204465488041099) started by @albatror*