### PR TITLE
Add toggle for logo in Info window

### DIFF
--- a/apex_guest/Client/Client/config.cpp
+++ b/apex_guest/Client/Client/config.cpp
@@ -83,6 +83,7 @@ void SaveConfig(const std::string& filename) {
     file << "skeleton_thickness " << v.skeleton_thickness << "\n";
     file << "spectator_notifier " << std::boolalpha << v.spectator_notifier << "\n";
     file << "info_window " << std::boolalpha << v.info_window << "\n";
+    file << "info_window_logo " << std::boolalpha << v.info_window_logo << "\n";
     file << "target_indicator " << std::boolalpha << v.target_indicator << "\n";
     file << "target_indicator_fov " << v.target_indicator_fov << "\n";
     file << "glowr " << glowr << "\n";
@@ -149,6 +150,7 @@ void LoadConfig(const std::string& filename) {
         else if (key == "skeleton_thickness") ss >> v.skeleton_thickness;
         else if (key == "spectator_notifier") ss >> std::boolalpha >> v.spectator_notifier;
         else if (key == "info_window") ss >> std::boolalpha >> v.info_window;
+        else if (key == "info_window_logo") ss >> std::boolalpha >> v.info_window_logo;
         else if (key == "target_indicator") ss >> std::boolalpha >> v.target_indicator;
         else if (key == "target_indicator_fov") ss >> v.target_indicator_fov;
         else if (key == "glowr") ss >> glowr;

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -268,6 +268,10 @@ void Overlay::RenderMenu()
 			ImGui::Checkbox(XorStr("Spectator list"), &v.spectator_notifier);
 			ImGui::SameLine();
 			ImGui::Checkbox(XorStr("Info window"), &v.info_window);
+			if (v.info_window) {
+				ImGui::SameLine();
+				ImGui::Checkbox(XorStr("Logo"), &v.info_window_logo);
+			}
 
 			ImGui::Checkbox(XorStr("Target Indicator"), &v.target_indicator);
 			if (v.target_indicator) {
@@ -368,16 +372,19 @@ void Overlay::RenderInfo()
 	ImGui::Unindent(12);
 
 	// Status Row: [Logo]
-	ID3D11ShaderResourceView* statusLogo = ready ? logoGreenTexture : logoRedTexture;
-	if (statusLogo)
+	if (v.info_window_logo)
 	{
-		float logoScale = 0.25f;
-		float scaledWidth = logoWidth * logoScale;
-		float scaledHeight = logoHeight * logoScale;
+		ID3D11ShaderResourceView* statusLogo = ready ? logoGreenTexture : logoRedTexture;
+		if (statusLogo)
+		{
+			float logoScale = 0.25f;
+			float scaledWidth = logoWidth * logoScale;
+			float scaledHeight = logoHeight * logoScale;
 
-		ImGui::SetCursorPosX((windowWidth - scaledWidth) * 0.5f);
-		ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 10.0f);
-		ImGui::Image((void*)statusLogo, ImVec2(scaledWidth, scaledHeight));
+			ImGui::SetCursorPosX((windowWidth - scaledWidth) * 0.5f);
+			ImGui::SetCursorPosY(ImGui::GetCursorPosY() + 10.0f);
+			ImGui::Image((void*)statusLogo, ImVec2(scaledWidth, scaledHeight));
+		}
 	}
 
 	ImGui::End();

--- a/apex_guest/Client/Client/overlay.h
+++ b/apex_guest/Client/Client/overlay.h
@@ -37,6 +37,7 @@ typedef struct visuals
 	bool skeleton = false;
 	bool spectator_notifier = false;
 	bool info_window = false;
+	bool info_window_logo = true;
 	bool target_indicator = false;
 	float target_indicator_fov = 10.0f;
 	bool triggerbot_fov_circle = false;


### PR DESCRIPTION
This change implements the updates from the branch `update-renderinfo-ui-10086591914138385042` which allows users to toggle the visibility of the logo in the Info window. The setting is integrated into the guest client's UI and its configuration persistence system.

---
*PR created automatically by Jules for task [3140428585027292187](https://jules.google.com/task/3140428585027292187) started by @albatror*