### PR TITLE
Enhance Triggerbot with Aim Assist and Visibility Checks

### DIFF
--- a/apex_dma/StuffBot.cpp
+++ b/apex_dma/StuffBot.cpp
@@ -62,6 +62,7 @@ void StuffBotLoop()
             uint64_t entitylist = g_Base + OFFSET_ENTITYLIST;
             int ent_count = firing_range ? 10000 : 1000;
             static std::unordered_map<uint64_t, float> last_crosshair_times;
+            static std::unordered_map<uint64_t, float> last_visible_times;
 
             for (int i = 0; i < ent_count; i++) {
                 uint64_t centity = 0;
@@ -73,27 +74,35 @@ void StuffBotLoop()
 
                 if (last_crosshair_times.find(centity) == last_crosshair_times.end()) {
                     last_crosshair_times[centity] = now_crosshair_target_time;
+                    float vis_time = 0;
+                    apex_mem.Read<float>(centity + OFFSET_VISIBLE_TIME, vis_time);
+                    last_visible_times[centity] = vis_time;
                     continue;
                 }
 
                 if (now_crosshair_target_time > last_crosshair_times[centity]) {
                     // Possible target detected by crosshair, now perform detailed checks
-                    int health = 0;
-                    apex_mem.Read<int>(centity + OFFSET_HEALTH, health);
-                    if (health <= 0) {
+                    Entity Target = getEntity(centity);
+                    if (!Target.isAlive() || (Target.isKnocked() && !firing_range)) {
                         last_crosshair_times[centity] = now_crosshair_target_time;
                         continue;
                     }
 
-                    int team = 0;
-                    apex_mem.Read<int>(centity + OFFSET_TEAM, team);
-                    if (team == LPlayer.getTeamId() && !firing_range) {
+                    // Visibility check
+                    float now_visible_time = 0;
+                    apex_mem.Read<float>(centity + OFFSET_VISIBLE_TIME, now_visible_time);
+                    if (now_visible_time <= last_visible_times[centity] && !firing_range) {
+                        last_crosshair_times[centity] = now_crosshair_target_time;
+                        continue;
+                    }
+                    last_visible_times[centity] = now_visible_time;
+
+                    if (Target.getTeamId() == LPlayer.getTeamId() && !firing_range) {
                         last_crosshair_times[centity] = now_crosshair_target_time;
                         continue;
                     }
 
                     // Check FOV using head bone for better accuracy
-                    Entity Target = getEntity(centity);
                     Vector HeadPos = Target.getBonePositionByHitbox(0);
                     if (HeadPos.IsZero()) {
                         last_crosshair_times[centity] = now_crosshair_target_time;
@@ -141,6 +150,7 @@ void StuffBotLoop()
                         TriggerBotRun(true);
                         trigger_again_time = now + std::chrono::milliseconds(80);
                         last_crosshair_times[centity] = now_crosshair_target_time;
+                        last_visible_times[centity] = now_visible_time;
                         break;
                     }
                     // Responsive logic: only update last_crosshair_times if the target is invalid or we shot.

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -230,7 +230,9 @@ void ProcessPlayer(Entity &LPlayer, Entity &target, uint64_t entitylist, int ind
 		if (entity_team < 0 || entity_team > 50 || entity_team == team_player)
 			return;
 	
-	bool visible = (target.lastVisTime() > lastvis_aim[index]);
+	bool visible = false;
+	if (index >= 0 && index < toRead)
+		visible = (target.lastVisTime() > lastvis_aim[index]);
 
 	// Use head position for FOV calculation to be more accurate at close range
 	Vector HeadPos = target.getBonePositionByHitbox(0);
@@ -254,7 +256,7 @@ void ProcessPlayer(Entity &LPlayer, Entity &target, uint64_t entitylist, int ind
 	{
 		// Stick to target
 	}
-	else if (aim == 2)
+	else if (aim == 2 || triggerbot_aiming)
 	{
 		if (visible && fov <= active_fov && dist <= active_dist)
 		{
@@ -286,7 +288,8 @@ void ProcessPlayer(Entity &LPlayer, Entity &target, uint64_t entitylist, int ind
 	////
 	SetPlayerGlow(LPlayer, target, index);
 	////
-	lastvis_aim[index] = target.lastVisTime();
+	if (index >= 0 && index < toRead)
+		lastvis_aim[index] = target.lastVisTime();
 }
 
 //walljump +//////////////////////////////////////
@@ -947,9 +950,9 @@ static void AimbotLoop()
 			wasZooming = isZooming;
 
 
-			if (aim > 0)
+			if (aim > 0 || triggerbot_aiming)
 			{
-				if (aimentity == 0 || !aiming)
+				if (aimentity == 0 || (!aiming && !triggerbot_aiming))
 				{
 					lock = false;
 					lastaimentity = 0;
@@ -983,6 +986,9 @@ static void AimbotLoop()
 				float current_smooth = is_zooming ? ads_smooth : hip_smooth;
 				float current_max_fov = is_zooming ? ads_fov : hip_fov;
 
+				if (triggerbot_aiming && triggerbot_fov > current_max_fov)
+					current_max_fov = triggerbot_fov;
+
 				auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - lock_start_time).count();
 				if (elapsed < 500) {
 					current_smooth *= 2.0f;
@@ -1001,7 +1007,7 @@ static void AimbotLoop()
 					continue;
 				}
 
-				if (aim == 2 && !is_aimentity_visible)
+				if ((aim == 2 || triggerbot_aiming) && !is_aimentity_visible)
 				{
 					continue;
 				}


### PR DESCRIPTION
This update integrates automatic aiming into the triggerbot when holding the Left Shift key. It ensures the reticle is positioned over a valid, visible, and alive target before the triggerbot initiates firing. The changes include updates to the main DMA processing loop for target selection and the triggerbot-specific loop for visibility-aware firing.

---
*PR created automatically by Jules for task [1917238963893805388](https://jules.google.com/task/1917238963893805388) started by @albatror*