### PR TITLE
Shield Visibility Checks and Drone ESP Implementation

### DIFF
--- a/apex_dma/Game.cpp
+++ b/apex_dma/Game.cpp
@@ -209,6 +209,61 @@ int Entity::getCurrentWeaponId()
 	apex_mem.Read<int>(wep_entity + OFFSET_WEAPON_NAME, weaponId);
 	return weaponId;
 }
+
+uint32_t Entity::getNetFlags()
+{
+	return *(uint32_t*)(buffer + OFFSET_NET_FLAGS);
+}
+
+bool Entity::isGibraltarShield()
+{
+	char signifier[33] = {};
+	apex_mem.ReadArray<char>(ptr + OFFSET_SIGN_NAME, signifier, 32);
+	if (strcmp(signifier, "prop_script") != 0) return false;
+	uint32_t netFlags;
+	apex_mem.Read<uint32_t>(ptr + OFFSET_NET_FLAGS, netFlags);
+	return netFlags == 286269440;
+}
+
+bool Entity::isRampartCover()
+{
+	char signifier[33] = {};
+	apex_mem.ReadArray<char>(ptr + OFFSET_SIGN_NAME, signifier, 32);
+	if (strcmp(signifier, "prop_script") != 0) return false;
+	char modelName[256] = { 0 };
+	getModelName(modelName, 256);
+	return (strstr(modelName, "rampart_cover_wall.rmdl") != nullptr);
+}
+
+bool Entity::isNewcastleShield()
+{
+	char signifier[33] = {};
+	apex_mem.ReadArray<char>(ptr + OFFSET_SIGN_NAME, signifier, 32);
+	if (strcmp(signifier, "prop_script") != 0) return false;
+	char modelName[256] = { 0 };
+	getModelName(modelName, 256);
+	return (strstr(modelName, "newcastle_mobile_shield.rmdl") != nullptr || strstr(modelName, "newcastle_castle_wall.rmdl") != nullptr);
+}
+
+bool Entity::isLifelineDrone()
+{
+	char signifier[33] = {};
+	apex_mem.ReadArray<char>(ptr + OFFSET_SIGN_NAME, signifier, 32);
+	if (strcmp(signifier, "prop_script") != 0) return false;
+	char modelName[256] = { 0 };
+	getModelName(modelName, 256);
+	return (strstr(modelName, "lifeline_drone.rmdl") != nullptr);
+}
+
+bool Entity::isCryptoDrone()
+{
+	char signifier[33] = {};
+	apex_mem.ReadArray<char>(ptr + OFFSET_SIGN_NAME, signifier, 32);
+	if (strcmp(signifier, "player_vehicle") != 0) return false;
+	char modelName[256] = { 0 };
+	getModelName(modelName, 256);
+	return (strstr(modelName, "crypto_drone.rmdl") != nullptr);
+}
 ///////////////////////////////
 
 Vector Entity::getBonePosition(int id)
@@ -385,6 +440,18 @@ void Entity::get_name(uint64_t g_Base, char* name)
     uint64_t name_ptr = 0;
     apex_mem.Read<uint64_t>(g_Base + OFFSET_NAME_LIST + ((name_index - 1) * 24), name_ptr);
 	apex_mem.ReadArray<char>(name_ptr, name, 32);
+}
+
+void Entity::getModelName(char* name, int max_len)
+{
+	uint64_t model_name_ptr = 0;
+	apex_mem.Read<uint64_t>(ptr + OFFSET_MODELNAME, model_name_ptr);
+	if (model_name_ptr) {
+		apex_mem.ReadArray<char>(model_name_ptr, name, max_len);
+	}
+	else {
+		strncpy(name, "unknown", max_len);
+	}
 }
 
 void Entity::getWeaponModelName(char* name, int max_len)

--- a/apex_dma/Game.h
+++ b/apex_dma/Game.h
@@ -85,9 +85,16 @@ public:
 	bool Observing(uint64_t local);
 	void get_name(uint64_t g_Base, char* name);
 	//void get_name(char *name);
+	void getModelName(char* name, int max_len);
 	void getWeaponModelName(char* name, int max_len);
 	float lastCrossHairTime();
 	int getCurrentWeaponId();
+	uint32_t getNetFlags();
+	bool isGibraltarShield();
+	bool isRampartCover();
+	bool isNewcastleShield();
+	bool isLifelineDrone();
+	bool isCryptoDrone();
 	////test////
 	int xp_level();
 

--- a/apex_dma/Math.cpp
+++ b/apex_dma/Math.cpp
@@ -51,3 +51,57 @@ float Math::SmoothStep(float edge0, float edge1, float x)
 	// Evaluate polynomial
 	return x * x * (3 - 2 * x);
 }
+
+bool Math::IsLineIntersectingSphere(const Vector& start, const Vector& end, const Vector& sphereCenter, float radius)
+{
+	const float CHECK_RADIUS = radius + 10.0f;
+	const float INTERSECT_RADIUS = radius;
+
+	auto getDistanceSqr = [](const Vector& point, const Vector& center) {
+		return (point.x - center.x) * (point.x - center.x)
+			+ (point.y - center.y) * (point.y - center.y)
+			+ (point.z - center.z) * (point.z - center.z);
+	};
+
+	float startDistSqr = getDistanceSqr(start, sphereCenter);
+	float endDistSqr = getDistanceSqr(end, sphereCenter);
+	float checkRadiusSqr = CHECK_RADIUS * CHECK_RADIUS;
+
+	// If one point is inside and the other is outside, the line must intersect the sphere surface
+	if ((startDistSqr <= checkRadiusSqr) ^ (endDistSqr <= checkRadiusSqr)) {
+		return true;
+	}
+
+	// If both points are inside, they can see each other through the dome
+	if (startDistSqr <= checkRadiusSqr && endDistSqr <= checkRadiusSqr) {
+		return false;
+	}
+
+	// Ray-Sphere intersection for both points outside
+	Vector dir = {
+		end.x - start.x,
+		end.y - start.y,
+		end.z - start.z
+	};
+
+	Vector oc = {
+		start.x - sphereCenter.x,
+		start.y - sphereCenter.y,
+		start.z - sphereCenter.z
+	};
+
+	float a = dir.x * dir.x + dir.y * dir.y + dir.z * dir.z;
+	float b = 2.0f * (oc.x * dir.x + oc.y * dir.y + oc.z * dir.z);
+	float c = (oc.x * oc.x + oc.y * oc.y + oc.z * oc.z) - (INTERSECT_RADIUS * INTERSECT_RADIUS);
+
+	float discriminant = b * b - 4 * a * c;
+
+	if (discriminant < 0) {
+		return false;
+	}
+
+	float t1 = (-b - sqrt(discriminant)) / (2 * a);
+	float t2 = (-b + sqrt(discriminant)) / (2 * a);
+
+	return (t1 >= 0 && t1 <= 1) || (t2 >= 0 && t2 <= 1);
+}

--- a/apex_dma/Math.h
+++ b/apex_dma/Math.h
@@ -29,4 +29,5 @@ namespace Math
 	double DotProduct(const Vector& v1, const float* v2);
 	QAngle CalcAngle(const Vector& src, const Vector& dst);
 	float SmoothStep(float edge0, float edge1, float x);
+	bool IsLineIntersectingSphere(const Vector& start, const Vector& end, const Vector& sphereCenter, float radius);
 }

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -110,6 +110,13 @@ bool valid = false;
 bool lock = false;
 bool is_aimentity_visible = false;
 
+struct Shield {
+	Vector origin;
+	float radius;
+	int type; // 0: Gibraltar, 1: Rampart, 2: Newcastle
+};
+std::vector<Shield> active_shields;
+
 int screen_width = 2560;
 int screen_height = 1440;
 
@@ -236,6 +243,20 @@ void ProcessPlayer(Entity &LPlayer, Entity &target, uint64_t entitylist, int ind
 	
 	bool visible = (target.lastVisTime() > lastvis_aim[index]);
 
+	if (visible)
+	{
+		Vector camPos = LPlayer.GetCamPos();
+		Vector targetHead = target.getBonePositionByHitbox(0);
+		for (const auto& shield : active_shields)
+		{
+			if (Math::IsLineIntersectingSphere(camPos, targetHead, shield.origin, shield.radius))
+			{
+				visible = false;
+				break;
+			}
+		}
+	}
+
 	// Use head position for FOV calculation to be more accurate at close range
 	Vector HeadPos = target.getBonePositionByHitbox(0);
 	float fov = Math::GetFov(LPlayer.GetViewAngles(), Math::CalcAngle(LPlayer.GetCamPos(), HeadPos));
@@ -350,6 +371,48 @@ Entity LPlayer = getEntity(LocalPlayer);
 			}
 
 			uint64_t entitylist = g_Base + OFFSET_ENTITYLIST;
+
+			static auto last_shield_update = std::chrono::steady_clock::now();
+			if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - last_shield_update).count() > 500) {
+				active_shields.clear();
+				for (int i = 0; i < 1000; i++)
+				{
+					uint64_t centity = 0;
+					apex_mem.Read<uint64_t>(entitylist + ((uint64_t)i << 5), centity);
+					if (centity == 0 || centity == LocalPlayer) continue;
+
+					char signifier[33] = {};
+					apex_mem.ReadArray<char>(centity + OFFSET_SIGN_NAME, signifier, 32);
+
+					if (strcmp(signifier, "prop_script") == 0) {
+						uint32_t netFlags = 0;
+						apex_mem.Read<uint32_t>(centity + OFFSET_NET_FLAGS, netFlags);
+						if (netFlags == 286269440) {
+							Vector pos;
+							apex_mem.Read<Vector>(centity + OFFSET_ORIGIN, pos);
+							active_shields.push_back({ pos, 220.0f, 0 });
+						} else {
+							// Check Rampart and Newcastle via model name (less frequent, so we only read if it's prop_script)
+							char modelName[256] = { 0 };
+							uint64_t model_name_ptr = 0;
+							apex_mem.Read<uint64_t>(centity + OFFSET_MODELNAME, model_name_ptr);
+							if (model_name_ptr) {
+								apex_mem.ReadArray<char>(model_name_ptr, modelName, 256);
+								if (strstr(modelName, "rampart_cover_wall.rmdl")) {
+									Vector pos;
+									apex_mem.Read<Vector>(centity + OFFSET_ORIGIN, pos);
+									active_shields.push_back({ pos, 80.0f, 1 });
+								} else if (strstr(modelName, "newcastle_mobile_shield.rmdl") || strstr(modelName, "newcastle_castle_wall.rmdl")) {
+									Vector pos;
+									apex_mem.Read<Vector>(centity + OFFSET_ORIGIN, pos);
+									active_shields.push_back({ pos, 100.0f, 2 });
+								}
+							}
+						}
+					}
+				}
+				last_shield_update = std::chrono::steady_clock::now();
+			}
 
 //////////////////////////////////
 
@@ -553,7 +616,23 @@ if (bhop && SuperKey) {
 						continue;
 
 					Entity Target = getEntity(centity);
-					if (!Target.isDummy())
+
+					bool isDrone = false;
+					char signifier[33] = {};
+					apex_mem.ReadArray<char>(centity + OFFSET_SIGN_NAME, signifier, 32);
+					if (strcmp(signifier, "player_vehicle") == 0 || strcmp(signifier, "prop_script") == 0) {
+						char modelName[256] = { 0 };
+						uint64_t model_name_ptr = 0;
+						apex_mem.Read<uint64_t>(centity + OFFSET_MODELNAME, model_name_ptr);
+						if (model_name_ptr) {
+							apex_mem.ReadArray<char>(model_name_ptr, modelName, 256);
+							if (strstr(modelName, "crypto_drone.rmdl") || strstr(modelName, "lifeline_drone.rmdl")) {
+								isDrone = true;
+							}
+						}
+					}
+
+					if (!Target.isDummy() && !isDrone)
 					{
 						continue;
 					}
@@ -686,7 +765,22 @@ Entity LPlayer = getEntity(LocalPlayer);
 
 						Entity Target = getEntity(centity);
 
-						if (!Target.isDummy())
+						bool isDrone = false;
+						char signifier[33] = {};
+						apex_mem.ReadArray<char>(centity + OFFSET_SIGN_NAME, signifier, 32);
+						if (strcmp(signifier, "player_vehicle") == 0 || strcmp(signifier, "prop_script") == 0) {
+							char modelName[256] = { 0 };
+							uint64_t model_name_ptr = 0;
+							apex_mem.Read<uint64_t>(centity + OFFSET_MODELNAME, model_name_ptr);
+							if (model_name_ptr) {
+								apex_mem.ReadArray<char>(model_name_ptr, modelName, 256);
+								if (strstr(modelName, "crypto_drone.rmdl") || strstr(modelName, "lifeline_drone.rmdl")) {
+									isDrone = true;
+								}
+							}
+						}
+
+						if (!Target.isDummy() && !isDrone)
 						{
 							continue;
 						}
@@ -772,7 +866,12 @@ Entity LPlayer = getEntity(LocalPlayer);
 								}
 							}
 
-							Target.get_name(g_Base, &players[c].name[0]);
+							if (isDrone) {
+								if (Target.isCryptoDrone()) strncpy(players[c].name, "Crypto Drone", 32);
+								else if (Target.isLifelineDrone()) strncpy(players[c].name, "Lifeline Drone", 32);
+							} else {
+								Target.get_name(g_Base, &players[c].name[0]);
+							}
 
 							char weaponModel[256] = { 0 };
 							Target.getWeaponModelName(weaponModel, 256);
@@ -807,7 +906,22 @@ Entity LPlayer = getEntity(LocalPlayer);
 
 						Entity Target = getEntity(centity);
 						
-						if (!Target.isPlayer())
+						bool isDrone = false;
+						char signifier[33] = {};
+						apex_mem.ReadArray<char>(centity + OFFSET_SIGN_NAME, signifier, 32);
+						if (strcmp(signifier, "player_vehicle") == 0 || strcmp(signifier, "prop_script") == 0) {
+							char modelName[256] = { 0 };
+							uint64_t model_name_ptr = 0;
+							apex_mem.Read<uint64_t>(centity + OFFSET_MODELNAME, model_name_ptr);
+							if (model_name_ptr) {
+								apex_mem.ReadArray<char>(model_name_ptr, modelName, 256);
+								if (strstr(modelName, "crypto_drone.rmdl") || strstr(modelName, "lifeline_drone.rmdl")) {
+									isDrone = true;
+								}
+							}
+						}
+
+						if (!Target.isPlayer() && !isDrone)
 						{
 							continue;
 						}
@@ -891,7 +1005,12 @@ Entity LPlayer = getEntity(LocalPlayer);
 								}
 							}
 
-							Target.get_name(g_Base, &players[i].name[0]);
+							if (isDrone) {
+								if (Target.isCryptoDrone()) strncpy(players[i].name, "Crypto Drone", 32);
+								else if (Target.isLifelineDrone()) strncpy(players[i].name, "Lifeline Drone", 32);
+							} else {
+								Target.get_name(g_Base, &players[i].name[0]);
+							}
 
 							char weaponModel[256] = { 0 };
 							Target.getWeaponModelName(weaponModel, 256);

--- a/apex_dma/offsets.h
+++ b/apex_dma/offsets.h
@@ -25,6 +25,7 @@
 #define OFFSET_ARMORTYPE 0x4854 //[RecvTable.DT_Player].m_armorType updated updated 2026/04/14
 #define OFFSET_NAME 0x479 //[RecvTable.DT_BaseEntity].m_iName updated 2026/04/14
 #define OFFSET_SIGN_NAME 0x470 //[RecvTable.DT_BaseEntity].m_iSignifierName updated 2026/04/14
+#define OFFSET_NET_FLAGS 0x02d8 //[RecvTable.DT_BaseEntity].m_networkedFlags
 #define OFFSET_ABS_VELOCITY 0x170 //[DataMap.DT_BaseEntity].m_vecAbsVelocity updated 2026/04/14
 //#define OFFSET_VISIBLE_TIME 0x1a64 //[Miscellaneous].CPlayer!lastVisibleTime updated 2026/04/14
 //#define OFFSET_LAST_AIMEDAT_TIME 0x1a64 //0x1a5c   //[Miscellaneous].CPlayer!lastVisibleTime + 0x8


### PR DESCRIPTION
This PR introduces visibility checks for deployable shields (Gibraltar, Rampart, Newcastle) and adds support for drones (Crypto, Lifeline) in the ESP. 

Key changes:
- Added `OFFSET_NET_FLAGS` to `offsets.h`.
- Implemented `Math::IsLineIntersectingSphere` with full 3D support.
- Enhanced the `Entity` class with tactical object identification helpers.
- Updated `apex_dma.cpp` to scan for active shields every 500ms to minimize PCIe overhead.
- Modified `ProcessPlayer` and ESP loops to include identified shields and drones.
- Ensured optimized DMA reads by checking signifiers before attempting model name reads.

---
*PR created automatically by Jules for task [18291654172243069420](https://jules.google.com/task/18291654172243069420) started by @albatror*