### PR TITLE
Implement Heirloom Changer feature

### DIFF
--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -72,6 +72,7 @@ float triggerbot_fov = 10.0f;
 bool superglide = false;
 bool bhop = false;
 bool walljump = false;
+bool heirloom_changer = false;
 
 ///////////////////////////
 //Player Glow Color and Brightness.
@@ -100,6 +101,7 @@ float glowbknocked = 1; //Blue 0-255, higher is brighter color.
 
 bool actions_t = false;
 bool esp_t = false;
+bool heirloom_t = false;
 bool aim_t = false;
 bool vars_t = false;
 bool item_t = false;
@@ -1172,6 +1174,9 @@ client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 51, aassist_dist_addr);
 uint64_t aassist_aiming_addr = 0;
 client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 52, aassist_aiming_addr);
 
+uint64_t heirloom_changer_addr = 0;
+client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 53, heirloom_changer_addr);
+
 uint32_t check = 0;
 client_mem.Read<uint32_t>(check_addr, check);
 
@@ -1295,6 +1300,8 @@ while (vars_t)
         if (aassist_dist_addr) client_mem.Read<float>(aassist_dist_addr, aassist_dist);
         if (aassist_aiming_addr) client_mem.Read<bool>(aassist_aiming_addr, aassist_aiming);
 
+        if (heirloom_changer_addr) client_mem.Read<bool>(heirloom_changer_addr, heirloom_changer);
+
         if (esp && next)
         {
             if (valid)
@@ -1314,6 +1321,74 @@ while (vars_t)
     }
 }
 vars_t = false;
+}
+
+void HeirloomChangerLoop()
+{
+	heirloom_t = true;
+	while (heirloom_t)
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		if (g_Base == 0 || c_Base == 0 || !heirloom_changer) continue;
+
+		uint64_t LocalPlayer = 0;
+		apex_mem.Read<uint64_t>(g_Base + OFFSET_LOCAL_ENT, LocalPlayer);
+		if (LocalPlayer == 0) continue;
+
+		uint32_t view_model_handle = 0;
+		apex_mem.Read<uint32_t>(LocalPlayer + OFFSET_VIEWMODEL, view_model_handle);
+		view_model_handle &= 0xFFFF;
+
+		uint64_t view_model_ptr = 0;
+		apex_mem.Read<uint64_t>(g_Base + OFFSET_ENTITYLIST + (view_model_handle << 5), view_model_ptr);
+		if (view_model_ptr == 0) continue;
+
+		char modelName[256];
+		uint64_t name_ptr = 0;
+		apex_mem.Read<uint64_t>(view_model_ptr + OFFSET_MODELNAME, name_ptr);
+		if (name_ptr == 0) continue;
+
+		apex_mem.ReadArray<char>(name_ptr, modelName, 256);
+		std::string model_name_str = std::string(modelName);
+
+		int cur_sequence = 0;
+		apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, cur_sequence);
+		int modelAniIndex = 0;
+		apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_MODEL_INDEX, modelAniIndex);
+
+		if (model_name_str.find("empty_handed") != std::string::npos)
+		{
+			// "mdl/techart/mshop/weapons/class/heirloom/agnostic/v24_cosmicmerc/heirloom_karambit_v24_cosmicmerc_v.rmdl"
+			const char* karambit_path = "mdl/techart/mshop/weapons/class/heirloom/agnostic/v24_cosmicmerc/heirloom_karambit_v24_cosmicmerc_v.rmdl";
+			apex_mem.WriteArray<char>(name_ptr, (char*)karambit_path, strlen(karambit_path) + 1);
+			apex_mem.Write<int>(view_model_ptr + OFFSET_CURFRAME, 5329);
+		}
+		else if (model_name_str.find("heirloom_karambit_v24_cosmicmerc_v") != std::string::npos)
+		{
+			uint32_t m_fFlags = 0;
+			apex_mem.Read<uint32_t>(LocalPlayer + OFFSET_FLAGS, m_fFlags);
+			int in_forward = 0;
+			apex_mem.Read<int>(g_Base + OFFSET_IN_FORWARD + 0x8, in_forward);
+			int in_attack = 0;
+			apex_mem.Read<int>(g_Base + OFFSET_IN_ATTACK + 0x8, in_attack);
+			int in_speed = 0;
+			apex_mem.Read<int>(g_Base + OFFSET_IN_SPEED + 0x8, in_speed);
+
+			int seq = 60;
+			if (m_fFlags == 65) seq = 60;
+			if (m_fFlags == 64) seq = 61;
+			if (in_forward) seq = 13;
+			if (m_fFlags == 67) seq = 74;
+			if (in_attack == 5) seq = 55;
+			if (in_speed == 5) seq = 73;
+
+			if (cur_sequence == 0 && modelAniIndex == 5329)
+			{
+				apex_mem.Write<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, 82);
+			}
+		}
+	}
+	heirloom_t = false;
 }
 
 // Item Glow Stuff
@@ -1462,6 +1537,7 @@ int main(int argc, char *argv[])
 	std::thread actions_thr;
 	std::thread itemglow_thr;
 	std::thread stuffbot_thr;
+	std::thread heirloom_thr;
 
 	std::thread vars_thr;
 	bool proc_not_found = false;
@@ -1475,15 +1551,17 @@ int main(int argc, char *argv[])
 				esp_t = false;
 				actions_t = false;
 				item_t = false;
+				heirloom_t = false;
 				extern bool stuff_t;
 				stuff_t = false;
 				g_Base = 0;
 
-				aimbot_thr.~thread();
-				esp_thr.~thread();
-				actions_thr.~thread();
-				itemglow_thr.~thread();
-				stuffbot_thr.~thread();
+				if (aimbot_thr.joinable()) aimbot_thr.detach();
+				if (esp_thr.joinable()) esp_thr.detach();
+				if (actions_thr.joinable()) actions_thr.detach();
+				if (itemglow_thr.joinable()) itemglow_thr.detach();
+				if (stuffbot_thr.joinable()) stuffbot_thr.detach();
+				if (heirloom_thr.joinable()) heirloom_thr.detach();
 
 			}
 
@@ -1512,11 +1590,13 @@ int main(int argc, char *argv[])
 				actions_thr = std::thread(DoActions);
 				stuffbot_thr = std::thread(StuffBotLoop);
 				itemglow_thr = std::thread(item_glow_t);
+				heirloom_thr = std::thread(HeirloomChangerLoop);
 				aimbot_thr.detach();
 				esp_thr.detach();
 				actions_thr.detach();
 				stuffbot_thr.detach();
 				itemglow_thr.detach();
+				heirloom_thr.detach();
 			}
 		}
 		else
@@ -1531,7 +1611,7 @@ int main(int argc, char *argv[])
 				vars_t = false;
 				c_Base = 0;
 
-				vars_thr.~thread();
+				if (vars_thr.joinable()) vars_thr.detach();
 			}
 			
 			std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -73,6 +73,7 @@ bool superglide = false;
 bool bhop = false;
 bool walljump = false;
 bool heirloom_changer = false;
+bool debug = false;
 
 ///////////////////////////
 //Player Glow Color and Brightness.
@@ -1177,6 +1178,9 @@ client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 52, aassist_aiming_addr)
 uint64_t heirloom_changer_addr = 0;
 client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 53, heirloom_changer_addr);
 
+uint64_t debug_addr = 0;
+client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 54, debug_addr);
+
 uint32_t check = 0;
 client_mem.Read<uint32_t>(check_addr, check);
 
@@ -1301,6 +1305,7 @@ while (vars_t)
         if (aassist_aiming_addr) client_mem.Read<bool>(aassist_aiming_addr, aassist_aiming);
 
         if (heirloom_changer_addr) client_mem.Read<bool>(heirloom_changer_addr, heirloom_changer);
+        if (debug_addr) client_mem.Read<bool>(debug_addr, debug);
 
         if (esp && next)
         {
@@ -1343,15 +1348,20 @@ void HeirloomChangerLoop()
 			continue;
 		}
 
-		// 🎯 Tick/frame detection
+		// 🎯 GlobalVars Frame Count
+		uint64_t globalVarsPtr = 0;
+		apex_mem.Read<uint64_t>(g_Base + OFFSET_GLOBAL_VARS, globalVarsPtr);
 		int current_frame = 0;
-		apex_mem.Read<int>(g_Base + OFFSET_GLOBAL_VARS + 0x0008, current_frame);
-		if (current_frame == last_frame)
+		if (globalVarsPtr)
 		{
-			std::this_thread::sleep_for(std::chrono::milliseconds(5));
-			continue;
+			apex_mem.Read<int>(globalVarsPtr + 0x0004, current_frame);
+			if (current_frame == last_frame)
+			{
+				std::this_thread::sleep_for(std::chrono::milliseconds(2));
+				continue;
+			}
+			last_frame = current_frame;
 		}
-		last_frame = current_frame;
 
 		uint64_t LocalPlayer = 0;
 		apex_mem.Read<uint64_t>(g_Base + OFFSET_LOCAL_ENT, LocalPlayer);
@@ -1361,60 +1371,51 @@ void HeirloomChangerLoop()
 			continue;
 		}
 
-		uint32_t view_model_handle = 0;
-		apex_mem.Read<uint32_t>(LocalPlayer + OFFSET_VIEWMODEL, view_model_handle);
-		view_model_handle &= 0xFFFF;
-
-		uint64_t view_model_ptr = 0;
-		apex_mem.Read<uint64_t>(g_Base + OFFSET_ENTITYLIST + (view_model_handle << 5), view_model_ptr);
-		if (!view_model_ptr)
+		for (int i = 0; i < 8; i++)
 		{
-			std::this_thread::sleep_for(std::chrono::milliseconds(100));
-			continue;
-		}
+			uint32_t view_model_handle = 0;
+			if (!apex_mem.Read<uint32_t>(LocalPlayer + OFFSET_VIEWMODEL + (i * 4), view_model_handle)) continue;
+			if (view_model_handle == 0 || view_model_handle == 0xFFFFFFFF) continue;
 
-		uint64_t name_ptr = 0;
-		apex_mem.Read<uint64_t>(view_model_ptr + OFFSET_MODELNAME, name_ptr);
-		if (!name_ptr)
-		{
-			std::this_thread::sleep_for(std::chrono::milliseconds(100));
-			continue;
-		}
+			view_model_handle &= 0xFFFF;
 
-		char modelName[128] = { 0 };
-		apex_mem.ReadArray<char>(name_ptr, modelName, sizeof(modelName));
-		std::string model_name_str(modelName);
+			uint64_t view_model_ptr = 0;
+			apex_mem.Read<uint64_t>(g_Base + OFFSET_ENTITYLIST + (view_model_handle << 5), view_model_ptr);
+			if (!view_model_ptr) continue;
 
-		int cur_sequence = 0;
-		apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, cur_sequence);
+			uint64_t name_ptr = 0;
+			apex_mem.Read<uint64_t>(view_model_ptr + OFFSET_MODELNAME, name_ptr);
+			if (!name_ptr) continue;
 
-		int modelAniIndex = 0;
-		apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_MODEL_INDEX, modelAniIndex);
+			char modelName[128] = { 0 };
+			apex_mem.ReadArray<char>(name_ptr, modelName, sizeof(modelName));
+			std::string model_name_str(modelName);
 
-		// 🔁 Skip if nothing changed
-		if (model_name_str == last_model &&
-			cur_sequence == last_sequence &&
-			modelAniIndex == last_model_index)
-		{
-			std::this_thread::sleep_for(std::chrono::milliseconds(50));
-			continue;
-		}
+			int cur_sequence = 0;
+			apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, cur_sequence);
 
-		last_model = model_name_str;
-		last_sequence = cur_sequence;
-		last_model_index = modelAniIndex;
+			int modelAniIndex = 0;
+			apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_MODEL_INDEX, modelAniIndex);
 
-		// ⚡ FAST MODE (active updates)
-		sleep_time = 5;
+			if (debug)
+			{
+				printf("VM[%d] Name: %s | Seq: %d | Index: %d\n", i, model_name_str.c_str(), cur_sequence, modelAniIndex);
+			}
 
-		// --- MODEL SWAP ---
-		if (model_name_str.find("empty_handed") != std::string::npos)
-		{
-			const char* path = "mdl/techart/mshop/weapons/class/heirloom/agnostic/v24_cosmicmerc/heirloom_karambit_v24_cosmicmerc_v.rmdl";
+			// ⚡ FAST MODE (active updates)
+			sleep_time = 2;
 
-			apex_mem.WriteArray<char>(name_ptr, (char*)path, strlen(path) + 1);
-			apex_mem.Write<int>(view_model_ptr + OFFSET_CURFRAME, 5329);
-		}
+			// --- MODEL SWAP ---
+			if (model_name_str.find("hand") != std::string::npos ||
+				model_name_str.find("melee") != std::string::npos ||
+				model_name_str.find("empty") != std::string::npos ||
+				model_name_str.find("survival") != std::string::npos)
+			{
+				const char* path = "mdl/techart/mshop/weapons/class/heirloom/agnostic/v24_cosmicmerc/heirloom_karambit_v24_cosmicmerc_v.rmdl";
+
+				apex_mem.WriteArray<char>(name_ptr, (char*)path, strlen(path) + 1);
+				apex_mem.Write<int>(view_model_ptr + OFFSET_CURFRAME, 5329);
+			}
 		else if (model_name_str.find("heirloom_karambit") != std::string::npos)
 		{
 			// 🎯 Only read inputs when needed
@@ -1449,6 +1450,7 @@ void HeirloomChangerLoop()
 			{
 				apex_mem.Write<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, 82);
 			}
+		}
 		}
 
 		std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time));

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -1326,14 +1326,40 @@ vars_t = false;
 void HeirloomChangerLoop()
 {
 	heirloom_t = true;
+
+	std::string last_model = "";
+	int last_sequence = -1;
+	int last_model_index = -1;
+	int last_frame = -1;
+
 	while (heirloom_t)
 	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(10));
-		if (g_Base == 0 || c_Base == 0 || !heirloom_changer) continue;
+		// Default: low CPU
+		int sleep_time = 50;
+
+		if (g_Base == 0 || !heirloom_changer)
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(200));
+			continue;
+		}
+
+		// 🎯 Tick/frame detection
+		int current_frame = 0;
+		apex_mem.Read<int>(g_Base + OFFSET_GLOBAL_VARS + 0x0008, current_frame);
+		if (current_frame == last_frame)
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(5));
+			continue;
+		}
+		last_frame = current_frame;
 
 		uint64_t LocalPlayer = 0;
 		apex_mem.Read<uint64_t>(g_Base + OFFSET_LOCAL_ENT, LocalPlayer);
-		if (LocalPlayer == 0) continue;
+		if (!LocalPlayer)
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			continue;
+		}
 
 		uint32_t view_model_handle = 0;
 		apex_mem.Read<uint32_t>(LocalPlayer + OFFSET_VIEWMODEL, view_model_handle);
@@ -1341,52 +1367,91 @@ void HeirloomChangerLoop()
 
 		uint64_t view_model_ptr = 0;
 		apex_mem.Read<uint64_t>(g_Base + OFFSET_ENTITYLIST + (view_model_handle << 5), view_model_ptr);
-		if (view_model_ptr == 0) continue;
+		if (!view_model_ptr)
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			continue;
+		}
 
-		char modelName[256];
 		uint64_t name_ptr = 0;
 		apex_mem.Read<uint64_t>(view_model_ptr + OFFSET_MODELNAME, name_ptr);
-		if (name_ptr == 0) continue;
+		if (!name_ptr)
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			continue;
+		}
 
-		apex_mem.ReadArray<char>(name_ptr, modelName, 256);
-		std::string model_name_str = std::string(modelName);
+		char modelName[128] = { 0 };
+		apex_mem.ReadArray<char>(name_ptr, modelName, sizeof(modelName));
+		std::string model_name_str(modelName);
 
 		int cur_sequence = 0;
 		apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, cur_sequence);
+
 		int modelAniIndex = 0;
 		apex_mem.Read<int>(view_model_ptr + OFFSET_ANIM_MODEL_INDEX, modelAniIndex);
 
+		// 🔁 Skip if nothing changed
+		if (model_name_str == last_model &&
+			cur_sequence == last_sequence &&
+			modelAniIndex == last_model_index)
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(50));
+			continue;
+		}
+
+		last_model = model_name_str;
+		last_sequence = cur_sequence;
+		last_model_index = modelAniIndex;
+
+		// ⚡ FAST MODE (active updates)
+		sleep_time = 5;
+
+		// --- MODEL SWAP ---
 		if (model_name_str.find("empty_handed") != std::string::npos)
 		{
-			// "mdl/techart/mshop/weapons/class/heirloom/agnostic/v24_cosmicmerc/heirloom_karambit_v24_cosmicmerc_v.rmdl"
-			const char* karambit_path = "mdl/techart/mshop/weapons/class/heirloom/agnostic/v24_cosmicmerc/heirloom_karambit_v24_cosmicmerc_v.rmdl";
-			apex_mem.WriteArray<char>(name_ptr, (char*)karambit_path, strlen(karambit_path) + 1);
+			const char* path = "mdl/techart/mshop/weapons/class/heirloom/agnostic/v24_cosmicmerc/heirloom_karambit_v24_cosmicmerc_v.rmdl";
+
+			apex_mem.WriteArray<char>(name_ptr, (char*)path, strlen(path) + 1);
 			apex_mem.Write<int>(view_model_ptr + OFFSET_CURFRAME, 5329);
 		}
-		else if (model_name_str.find("heirloom_karambit_v24_cosmicmerc_v") != std::string::npos)
+		else if (model_name_str.find("heirloom_karambit") != std::string::npos)
 		{
+			// 🎯 Only read inputs when needed
 			uint32_t m_fFlags = 0;
 			apex_mem.Read<uint32_t>(LocalPlayer + OFFSET_FLAGS, m_fFlags);
-			int in_forward = 0;
-			apex_mem.Read<int>(g_Base + OFFSET_IN_FORWARD + 0x8, in_forward);
-			int in_attack = 0;
-			apex_mem.Read<int>(g_Base + OFFSET_IN_ATTACK + 0x8, in_attack);
-			int in_speed = 0;
-			apex_mem.Read<int>(g_Base + OFFSET_IN_SPEED + 0x8, in_speed);
 
 			int seq = 60;
-			if (m_fFlags == 65) seq = 60;
+
 			if (m_fFlags == 64) seq = 61;
-			if (in_forward) seq = 13;
 			if (m_fFlags == 67) seq = 74;
+
+			int in_forward = 0;
+			apex_mem.Read<int>(g_Base + OFFSET_IN_FORWARD + 0x8, in_forward);
+			if (in_forward) seq = 13;
+
+			int in_attack = 0;
+			apex_mem.Read<int>(g_Base + OFFSET_IN_ATTACK + 0x8, in_attack);
 			if (in_attack == 5) seq = 55;
+
+			int in_speed = 0;
+			apex_mem.Read<int>(g_Base + OFFSET_IN_SPEED + 0x8, in_speed);
 			if (in_speed == 5) seq = 73;
 
+			// ✅ Only write if needed
+			if (cur_sequence != seq)
+			{
+				apex_mem.Write<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, seq);
+			}
+
+			// fallback fix
 			if (cur_sequence == 0 && modelAniIndex == 5329)
 			{
 				apex_mem.Write<int>(view_model_ptr + OFFSET_ANIM_SEQUENCE, 82);
 			}
 		}
+
+		std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time));
 	}
 	heirloom_t = false;
 }

--- a/apex_dma/offsets.h
+++ b/apex_dma/offsets.h
@@ -60,6 +60,7 @@
 #define OFFSET_IN_ZOOM 0x3d9afa0 //[Buttons].in_zoom updated 2026/05/05
 #define OFFSET_IN_FORWARD 0x3d9b048 //[Buttons].in_forward updated 2026/05/05
 #define OFFSET_IN_BACKWARD 0x3d9b070 //[Buttons].in_backward updated 2026/05/05
+#define OFFSET_IN_SPEED 0x3d9a5e0 //[Buttons].in_speed updated 2026/05/05
  
 #define OFFSET_LIFE_STATE 0x690 //[RecvTable.DT_Player].m_lifeState updated 2026/05/05
 #define OFFSET_BLEED_OUT_STATE 0x27e0 //[RecvTable.DT_Player].m_bleedoutState updated 2026/05/05
@@ -125,3 +126,8 @@
 #define OFFSET_m_xp		    0x384c //[RecvTable.DT_Player].m_xp updated 2026/05/05
 #define OFFSET_GRADE 0x344 //[RecvTable.DT_BaseEntity].m_grade updated 2026/05/05
 #define OFFSET_PLATFORM 0x2630 //[DT_Player].m_hardware updated 2026/05/05
+
+#define OFFSET_VIEWMODEL 0x2e00 //[RecvTable.DT_Player].m_hViewModels updated 2026/05/05
+#define OFFSET_CURFRAME 0xd8 //[DataMap.CBaseViewModel].m_currentFrame.modelIndex updated 2026/05/05
+#define OFFSET_ANIM_SEQUENCE 0xe48 //m_currentFrameBaseAnimating.animSequence
+#define OFFSET_ANIM_MODEL_INDEX 0xe40 //m_currentFrameBaseAnimating.animModelIndex

--- a/apex_dma/offsets.h
+++ b/apex_dma/offsets.h
@@ -127,7 +127,7 @@
 #define OFFSET_GRADE 0x344 //[RecvTable.DT_BaseEntity].m_grade updated 2026/05/05
 #define OFFSET_PLATFORM 0x2630 //[DT_Player].m_hardware updated 2026/05/05
 
-#define OFFSET_VIEWMODEL 0x2e00 //[RecvTable.DT_Player].m_hViewModels updated 2026/05/05
+#define OFFSET_VIEWMODEL 0x2e28 //[RecvTable.DT_Player].m_hViewModels updated 2026/05/05
 #define OFFSET_CURFRAME 0xd8 //[DataMap.CBaseViewModel].m_currentFrame.modelIndex updated 2026/05/05
 #define OFFSET_ANIM_SEQUENCE 0xe48 //m_currentFrameBaseAnimating.animSequence
 #define OFFSET_ANIM_MODEL_INDEX 0xe40 //m_currentFrameBaseAnimating.animModelIndex

--- a/apex_guest/Client/Client/config.cpp
+++ b/apex_guest/Client/Client/config.cpp
@@ -40,6 +40,7 @@ extern bool triggerbot;
 extern bool aassist;
 extern float aassist_dist;
 extern bool heirloom_changer;
+extern bool debug;
 extern bool superglide;
 extern bool bhop;
 extern bool walljump;
@@ -109,6 +110,7 @@ void SaveConfig(const std::string& filename) {
     file << "aassist " << std::boolalpha << aassist << "\n";
     file << "aassist_dist " << aassist_dist << "\n";
     file << "heirloom_changer " << std::boolalpha << heirloom_changer << "\n";
+    file << "debug " << std::boolalpha << debug << "\n";
     file << "superglide " << std::boolalpha << superglide << "\n";
     file << "bhop " << std::boolalpha << bhop << "\n";
     file << "walljump " << std::boolalpha << walljump << "\n";
@@ -179,6 +181,7 @@ void LoadConfig(const std::string& filename) {
         else if (key == "aassist") ss >> std::boolalpha >> aassist;
         else if (key == "aassist_dist") ss >> aassist_dist;
         else if (key == "heirloom_changer") ss >> std::boolalpha >> heirloom_changer;
+        else if (key == "debug") ss >> std::boolalpha >> debug;
         else if (key == "superglide") ss >> std::boolalpha >> superglide;
         else if (key == "bhop") ss >> std::boolalpha >> bhop;
         else if (key == "walljump") ss >> std::boolalpha >> walljump;

--- a/apex_guest/Client/Client/config.cpp
+++ b/apex_guest/Client/Client/config.cpp
@@ -39,6 +39,7 @@ extern bool onevone;
 extern bool triggerbot;
 extern bool aassist;
 extern float aassist_dist;
+extern bool heirloom_changer;
 extern bool superglide;
 extern bool bhop;
 extern bool walljump;
@@ -107,6 +108,7 @@ void SaveConfig(const std::string& filename) {
     file << "triggerbot " << std::boolalpha << triggerbot << "\n";
     file << "aassist " << std::boolalpha << aassist << "\n";
     file << "aassist_dist " << aassist_dist << "\n";
+    file << "heirloom_changer " << std::boolalpha << heirloom_changer << "\n";
     file << "superglide " << std::boolalpha << superglide << "\n";
     file << "bhop " << std::boolalpha << bhop << "\n";
     file << "walljump " << std::boolalpha << walljump << "\n";
@@ -176,6 +178,7 @@ void LoadConfig(const std::string& filename) {
         else if (key == "triggerbot") ss >> std::boolalpha >> triggerbot;
         else if (key == "aassist") ss >> std::boolalpha >> aassist;
         else if (key == "aassist_dist") ss >> aassist_dist;
+        else if (key == "heirloom_changer") ss >> std::boolalpha >> heirloom_changer;
         else if (key == "superglide") ss >> std::boolalpha >> superglide;
         else if (key == "bhop") ss >> std::boolalpha >> bhop;
         else if (key == "walljump") ss >> std::boolalpha >> walljump;

--- a/apex_guest/Client/Client/config.h
+++ b/apex_guest/Client/Client/config.h
@@ -12,3 +12,4 @@ extern float hip_smooth;
 extern bool aassist;
 extern float aassist_dist;
 extern bool heirloom_changer;
+extern bool debug;

--- a/apex_guest/Client/Client/config.h
+++ b/apex_guest/Client/Client/config.h
@@ -11,3 +11,4 @@ extern float hip_fov;
 extern float hip_smooth;
 extern bool aassist;
 extern float aassist_dist;
+extern bool heirloom_changer;

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -77,6 +77,8 @@ bool aassist = false;
 float aassist_dist = 50.0f * 40.0f;
 bool aassist_aiming = false;
 
+bool heirloom_changer = false;
+
 int bone = 2;
 // Declare constants for key detection
 int SuperKey = VK_SPACE;  // VK_SPACE is the spacebar keycode
@@ -485,6 +487,7 @@ int main(int argc, char** argv)
 	add[50] = (uintptr_t)&aassist;
 	add[51] = (uintptr_t)&aassist_dist;
 	add[52] = (uintptr_t)&aassist_aiming;
+	add[53] = (uintptr_t)&heirloom_changer;
 
 	printf(XorStr("add offset: 0x%I64x\n"), (uint64_t)&add[0] - (uint64_t)GetModuleHandle(NULL));
 

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -78,6 +78,7 @@ float aassist_dist = 50.0f * 40.0f;
 bool aassist_aiming = false;
 
 bool heirloom_changer = false;
+bool debug = false;
 
 int bone = 2;
 // Declare constants for key detection
@@ -488,6 +489,7 @@ int main(int argc, char** argv)
 	add[51] = (uintptr_t)&aassist_dist;
 	add[52] = (uintptr_t)&aassist_aiming;
 	add[53] = (uintptr_t)&heirloom_changer;
+	add[54] = (uintptr_t)&debug;
 
 	printf(XorStr("add offset: 0x%I64x\n"), (uint64_t)&add[0] - (uint64_t)GetModuleHandle(NULL));
 
@@ -611,6 +613,16 @@ int main(int argc, char** argv)
 		else if (!IsKeyDown(VK_F10) && k_f10 == 1)
 		{
 			k_f10 = 0;
+		}
+
+		if (IsKeyDown(VK_F11) && k_f11 == 0)
+		{
+			k_f11 = 1;
+			debug = !debug;
+		}
+		else if (!IsKeyDown(VK_F11) && k_f11 == 1)
+		{
+			k_f11 = 0;
 		}
 
 		if (IsKeyDown(VK_LEFT))

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -31,6 +31,8 @@ extern bool firing_range;
 extern bool triggerbot;
 extern float triggerbot_fov;
 
+extern bool heirloom_changer;
+
 extern bool aassist;
 extern float aassist_dist;
 
@@ -193,6 +195,8 @@ void Overlay::RenderMenu()
 			ImGui::SliderFloat(XorStr("Trigger FOV"), &triggerbot_fov, 1.0f, 1000.0f, "%.2f");
 
 			ImGui::Checkbox(XorStr("Aim Assist (RMB)"), &aassist);
+
+			ImGui::Checkbox(XorStr("Heirloom Changer"), &heirloom_changer);
 
 			ImGui::EndTabItem();
 		}
@@ -377,6 +381,9 @@ void Overlay::RenderInfo()
 	ImGui::TextColored(WHITE, XorStr("-"));
 	ImGui::SameLine(240);
 	ImGui::TextColored(triggerbot ? GREEN : RED, XorStr("Triggerbot"));
+
+	// Row 4: - Heirloom
+	ImGui::TextColored(heirloom_changer ? GREEN : RED, XorStr("- Heirloom"));
 
 	float windowWidth = ImGui::GetWindowSize().x;
 	ImGui::Unindent(12);

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -32,6 +32,7 @@ extern bool triggerbot;
 extern float triggerbot_fov;
 
 extern bool heirloom_changer;
+extern bool debug;
 
 extern bool aassist;
 extern float aassist_dist;
@@ -197,6 +198,7 @@ void Overlay::RenderMenu()
 			ImGui::Checkbox(XorStr("Aim Assist (RMB)"), &aassist);
 
 			ImGui::Checkbox(XorStr("Heirloom Changer"), &heirloom_changer);
+			ImGui::Checkbox(XorStr("Debug Logging"), &debug);
 
 			ImGui::EndTabItem();
 		}


### PR DESCRIPTION
This change introduces an Heirloom Changer feature based on community research. It allows users to replace the default empty-handed view model with the Cosmic Mercenary Karambit. 

Key technical changes:
1.  **Offsets**: Added necessary offsets for view model handling and animation control in `apex_dma/offsets.h`.
2.  **Logic**: Implemented `HeirloomChangerLoop` in the DMA host, which monitors the local player's view model. When empty-handed, it patches the model path and index. It also forces a specific animation sequence to prevent flickering reported in early versions of this hack.
3.  **Synchronization**: Expanded the host-guest communication array to synchronize the feature state.
4.  **UI/UX**: Added a toggle for the feature in the guest client's "Main" menu and a status indicator in the "Info" window. The setting is persisted in `Settings.txt`.
5.  **Stability**: Replaced unsafe manual thread destructor calls with proper `joinable()` checks and `detach()` calls to prevent potential crashes during process re-initialization.

---
*PR created automatically by Jules for task [3637992452560177850](https://jules.google.com/task/3637992452560177850) started by @albatror*