### PR TITLE
Fix "Unknown" weapon names and update outdated offsets

### DIFF
--- a/apex_dma/Game.cpp
+++ b/apex_dma/Game.cpp
@@ -200,13 +200,16 @@ float Entity::lastCrossHairTime()
 int Entity::getCurrentWeaponId()
 {
 	uint64_t wep_handle = 0;
-	apex_mem.Read<uint64_t>(ptr + OFFSET_WEAPON, wep_handle);
+	uint64_t wep_off = (offsets.Weapon > 0) ? offsets.Weapon : OFFSET_WEAPON;
+	apex_mem.Read<uint64_t>(ptr + wep_off, wep_handle);
 	wep_handle &= 0xffff;
 	uint64_t wep_entity = 0;
-	apex_mem.Read<uint64_t>(apex_mem.get_proc_baseaddr() + OFFSET_ENTITYLIST + (wep_handle << 5), wep_entity);
+	uint64_t entity_list_off = (offsets.EntityList > 0) ? offsets.EntityList : OFFSET_ENTITYLIST;
+	apex_mem.Read<uint64_t>(apex_mem.get_proc_baseaddr() + entity_list_off + (wep_handle << 5), wep_entity);
 	if (!wep_entity) return -1;
 	int weaponId = 0;
-	apex_mem.Read<int>(wep_entity + OFFSET_WEAPON_NAME, weaponId);
+	uint64_t wep_name_off = (offsets.WeaponName > 0) ? offsets.WeaponName : OFFSET_WEAPON_NAME;
+	apex_mem.Read<int>(wep_entity + wep_name_off, weaponId);
 	return weaponId;
 }
 ///////////////////////////////
@@ -383,17 +386,20 @@ void Entity::get_name(uint64_t g_Base, char* name)
      int name_index;
     apex_mem.Read<int>(ptr + 0x38, name_index);
     uint64_t name_ptr = 0;
-    apex_mem.Read<uint64_t>(g_Base + OFFSET_NAME_LIST + ((name_index - 1) * 24), name_ptr);
+	uint64_t name_list_off = (offsets.NameList > 0) ? offsets.NameList : OFFSET_NAME_LIST;
+    apex_mem.Read<uint64_t>(g_Base + name_list_off + ((name_index - 1) * 24), name_ptr);
 	apex_mem.ReadArray<char>(name_ptr, name, 32);
 }
 
 void Entity::getWeaponModelName(char* name, int max_len)
 {
 	uint64_t wep_handle = 0;
-	apex_mem.Read<uint64_t>(ptr + OFFSET_WEAPON, wep_handle);
+	uint64_t wep_off = (offsets.Weapon > 0) ? offsets.Weapon : OFFSET_WEAPON;
+	apex_mem.Read<uint64_t>(ptr + wep_off, wep_handle);
 	wep_handle &= 0xffff;
 	uint64_t wep_entity = 0;
-	apex_mem.Read<uint64_t>(apex_mem.get_proc_baseaddr() + OFFSET_ENTITYLIST + (wep_handle << 5), wep_entity);
+	uint64_t entity_list_off = (offsets.EntityList > 0) ? offsets.EntityList : OFFSET_ENTITYLIST;
+	apex_mem.Read<uint64_t>(apex_mem.get_proc_baseaddr() + entity_list_off + (wep_handle << 5), wep_entity);
 	if (!wep_entity) {
 		strncpy(name, "unknown", max_len);
 		return;
@@ -665,9 +671,11 @@ bool WorldToScreen(Vector from, float* m_vMatrix, int targetWidth, int targetHei
 void WeaponXEntity::update(uint64_t LocalPlayer)
 {
     extern uint64_t g_Base;
-	uint64_t entitylist = g_Base + OFFSET_ENTITYLIST;
+	uint64_t entity_list_off = (offsets.EntityList > 0) ? offsets.EntityList : OFFSET_ENTITYLIST;
+	uint64_t entitylist = g_Base + entity_list_off;
 	uint64_t wephandle = 0;
-    apex_mem.Read<uint64_t>(LocalPlayer + OFFSET_WEAPON, wephandle);
+	uint64_t wep_off = (offsets.Weapon > 0) ? offsets.Weapon : OFFSET_WEAPON;
+    apex_mem.Read<uint64_t>(LocalPlayer + wep_off, wephandle);
 	
 	wephandle &= 0xffff;
 

--- a/apex_dma/offsets.h
+++ b/apex_dma/offsets.h
@@ -76,7 +76,7 @@
 #define OFFSET_MATRIX 0x11a350 //[Miscellaneous].ViewMatrix updated 2026/05/05
 #define OFFSET_RENDER 0x3d97d78 //[Miscellaneous].ViewRender updated 2026/05/05
  
-#define OFFSET_WEAPON 0x1888 //0x15f0 //[RecvTable.DT_WeaponX].m_weaponNameIndex updated 2026/05/05
+#define OFFSET_WEAPON 0x19e4 //0x1888 //0x15f0 //[RecvTable.DT_WeaponX].m_weaponNameIndex updated 2026/05/05
 #define OFFSET_BULLET_SPEED 0x1af8 + 0xd80 //[Miscellaneous].WeaponSettingsMeta_base + [weaponSettings].projectile_launch_speed updated 2026/05/05
 #define OFFSET_BULLET_SCALE OFFSET_BULLET_SPEED + 0x08 //0x1af8 + 0xd88 //[Miscellaneous].WeaponSettingsMeta_base + [weaponSettings].projectile_gravity_scale updated 2026/05/05
 

--- a/apex_dma/offsets_dynamic.cpp
+++ b/apex_dma/offsets_dynamic.cpp
@@ -63,6 +63,8 @@ bool load_offsets_from_ini(const char* offsets_file, const char* convars_file, c
     if (off_data.count("[.Miscellaneous]CPlayer!lastVisibleTime")) offsets.VisibleTime = off_data["[.Miscellaneous]CPlayer!lastVisibleTime"];
     if (off_data.count("[RecvTable.DT_Player]m_bZooming")) offsets.Zooming = off_data["[RecvTable.DT_Player]m_bZooming"];
     if (off_data.count("[DataMap.DT_BaseEntity]m_currentFrame.viewOffset")) offsets.ViewOffset = off_data["[DataMap.DT_BaseEntity]m_currentFrame.viewOffset"];
+    if (off_data.count("[.Miscellaneous]m_latestNonOffhandWeapons")) offsets.Weapon = off_data["[.Miscellaneous]m_latestNonOffhandWeapons"];
+    if (off_data.count("[RecvTable.DT_WeaponX]m_weaponNameIndex")) offsets.WeaponName = off_data["[RecvTable.DT_WeaponX]m_weaponNameIndex"];
 
     if (off_data.count("[RecvTable.DT_Player]m_duckState")) offsets.InDuckState = off_data["[RecvTable.DT_Player]m_duckState"];
     if (off_data.count("[DataMap.DT_Player]m_traversalProgress")) offsets.TraversalProgress = off_data["[DataMap.DT_Player]m_traversalProgress"];


### PR DESCRIPTION
This PR fixes the issue where target weapon names were consistently displayed as "Unknown" due to outdated memory offsets. 

Key changes:
1.  **Corrected Offsets**: The hardcoded `OFFSET_WEAPON` (the handle offset on the player entity) was updated from `0x1888` to `0x19e4`, matching the latest game version's `m_latestNonOffhandWeapons`.
2.  **Dynamic Offset Support**: Extended the `DynamicOffsets` system to load `Weapon` and `WeaponName` from the configuration INI files.
3.  **Resilient Weapon Logic**: Refactored weapon identification logic in `Game.cpp` to prioritize dynamic offsets with robust fallbacks to hardcoded constants, ensuring better stability across game updates.
4.  **Improved Name Resolution**: Fixed `Entity::get_name` to use dynamic offsets for the name list.

These changes restore correct weapon identification and name resolution for target entities.

---
*PR created automatically by Jules for task [10464996617989169344](https://jules.google.com/task/10464996617989169344) started by @albatror*