### PR TITLE
Optimize Triggerbot and Add Multi-Bone Support

### DIFF
--- a/apex_dma/StuffBot.cpp
+++ b/apex_dma/StuffBot.cpp
@@ -9,6 +9,7 @@
 extern Memory apex_mem;
 extern uint64_t g_Base;
 extern bool triggerbot;
+extern int triggerbot_hitbox;
 extern bool triggerbot_aiming;
 extern float triggerbot_fov;
 extern float aim_dist;
@@ -90,26 +91,60 @@ void StuffBotLoop()
                         continue;
                     }
 
-                    // Check FOV using head bone for better accuracy
+                    // Check FOV using selected hitboxes
                     Entity Target = getEntity(centity);
-                    Vector HeadPos = Target.getBonePositionByHitbox(0);
-                    if (HeadPos.IsZero()) {
-                        last_crosshair_times[centity] = now_crosshair_target_time;
-                        continue;
-                    }
-
-                    float fov = Math::GetFov(LPlayer.GetViewAngles(), Math::CalcAngle(LPlayer.GetCamPos(), HeadPos));
-
-                    bool can_shoot = false;
-                    float dist = LPlayer.getPosition().DistTo(Target.getPosition());
+                    Vector LPlayerPos = LPlayer.getPosition();
+                    Vector TargetPos = Target.getPosition();
+                    float dist = LPlayerPos.DistTo(TargetPos);
 
                     if (aim_dist > 0.0f && dist > aim_dist) {
                         last_crosshair_times[centity] = now_crosshair_target_time;
                         continue;
                     }
 
-                    if (fov <= triggerbot_fov) {
-                        can_shoot = true;
+                    bool can_shoot = false;
+                    Vector CamPos = LPlayer.GetCamPos();
+                    QAngle ViewAngles = LPlayer.GetViewAngles();
+
+                    if (triggerbot_hitbox == -1) // NONE mode: uses absOrigin.z + static value
+                    {
+                        Vector targetHitPos = TargetPos;
+                        targetHitPos.z += 60.0f; // Approx chest height
+                        float fov = Math::GetFov(ViewAngles, Math::CalcAngle(CamPos, targetHitPos));
+                        if (fov <= triggerbot_fov) can_shoot = true;
+                    }
+                    else if (triggerbot_hitbox >= 0 && triggerbot_hitbox <= 100) // Static bone mode
+                    {
+                        Vector BonePos = Target.getBonePositionByHitbox(triggerbot_hitbox);
+                        if (!BonePos.IsZero()) {
+                            float fov = Math::GetFov(ViewAngles, Math::CalcAngle(CamPos, BonePos));
+                            if (fov <= triggerbot_fov) can_shoot = true;
+                        }
+                    }
+                    else // Multi-bone modes
+                    {
+                        static const int NEAR3_BONES[] = { 0, 1, 2 };
+                        static const int NEAR6_BONES[] = { 0, 1, 2, 3, 4, 11 };
+                        static const int NEAR12_BONES[] = { 0, 1, 2, 3, 4, 5, 8, 11, 12, 14, 15, 6 };
+
+                        const int* pBones = nullptr;
+                        int boneCount = 0;
+
+                        if (triggerbot_hitbox == 101) { pBones = NEAR3_BONES; boneCount = 3; }
+                        else if (triggerbot_hitbox == 102) { pBones = NEAR6_BONES; boneCount = 6; }
+                        else if (triggerbot_hitbox == 103) { pBones = NEAR12_BONES; boneCount = 12; }
+                        else if (triggerbot_hitbox == 104) { boneCount = 17; } // ALL
+
+                        for (int b = 0; b < boneCount; b++) {
+                            int boneID = (triggerbot_hitbox == 104) ? b : pBones[b];
+                            Vector BonePos = Target.getBonePositionByHitbox(boneID);
+                            if (BonePos.IsZero()) continue;
+                            float fov = Math::GetFov(ViewAngles, Math::CalcAngle(CamPos, BonePos));
+                            if (fov <= triggerbot_fov) {
+                                can_shoot = true;
+                                break;
+                            }
+                        }
                     }
 
                     if (can_shoot) {

--- a/apex_dma/apex_dma.cpp
+++ b/apex_dma/apex_dma.cpp
@@ -65,6 +65,7 @@ float aassist_dist = 50.0f * 40.0f;
 bool aassist_aiming = false;
 
 bool triggerbot = false;
+int triggerbot_hitbox = 2;
 int triggerbot_key = 0xA0; // VK_LSHIFT
 bool triggerbot_aiming = false;
 float triggerbot_fov = 10.0f;
@@ -1172,6 +1173,9 @@ client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 51, aassist_dist_addr);
 uint64_t aassist_aiming_addr = 0;
 client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 52, aassist_aiming_addr);
 
+uint64_t triggerbot_hitbox_addr = 0;
+client_mem.Read<uint64_t>(add_addr + sizeof(uint64_t) * 53, triggerbot_hitbox_addr);
+
 uint32_t check = 0;
 client_mem.Read<uint32_t>(check_addr, check);
 
@@ -1294,6 +1298,7 @@ while (vars_t)
         if (aassist_addr) client_mem.Read<bool>(aassist_addr, aassist);
         if (aassist_dist_addr) client_mem.Read<float>(aassist_dist_addr, aassist_dist);
         if (aassist_aiming_addr) client_mem.Read<bool>(aassist_aiming_addr, aassist_aiming);
+        if (triggerbot_hitbox_addr) client_mem.Read<int>(triggerbot_hitbox_addr, triggerbot_hitbox);
 
         if (esp && next)
         {

--- a/apex_guest/Client/Client/config.cpp
+++ b/apex_guest/Client/Client/config.cpp
@@ -37,6 +37,7 @@ extern float glowcolorknocked[3];
 extern bool firing_range;
 extern bool onevone;
 extern bool triggerbot;
+extern int triggerbot_hitbox;
 extern bool aassist;
 extern float aassist_dist;
 extern bool superglide;
@@ -105,6 +106,7 @@ void SaveConfig(const std::string& filename) {
     file << "firing_range " << std::boolalpha << firing_range << "\n";
     file << "onevone " << std::boolalpha << onevone << "\n";
     file << "triggerbot " << std::boolalpha << triggerbot << "\n";
+    file << "triggerbot_hitbox " << triggerbot_hitbox << "\n";
     file << "aassist " << std::boolalpha << aassist << "\n";
     file << "aassist_dist " << aassist_dist << "\n";
     file << "superglide " << std::boolalpha << superglide << "\n";
@@ -174,6 +176,7 @@ void LoadConfig(const std::string& filename) {
         else if (key == "firing_range") ss >> std::boolalpha >> firing_range;
         else if (key == "onevone") ss >> std::boolalpha >> onevone;
         else if (key == "triggerbot") ss >> std::boolalpha >> triggerbot;
+        else if (key == "triggerbot_hitbox") ss >> triggerbot_hitbox;
         else if (key == "aassist") ss >> std::boolalpha >> aassist;
         else if (key == "aassist_dist") ss >> aassist_dist;
         else if (key == "superglide") ss >> std::boolalpha >> superglide;

--- a/apex_guest/Client/Client/main.cpp
+++ b/apex_guest/Client/Client/main.cpp
@@ -45,6 +45,7 @@ int aim_key = VK_LBUTTON;
 int aim_key2 = VK_RBUTTON;
 
 bool triggerbot = false;
+int triggerbot_hitbox = 2;
 int triggerbot_key = VK_LSHIFT;
 bool triggerbot_aiming = false;
 float triggerbot_fov = 10.0f;
@@ -485,6 +486,7 @@ int main(int argc, char** argv)
 	add[50] = (uintptr_t)&aassist;
 	add[51] = (uintptr_t)&aassist_dist;
 	add[52] = (uintptr_t)&aassist_aiming;
+	add[53] = (uintptr_t)&triggerbot_hitbox;
 
 	printf(XorStr("add offset: 0x%I64x\n"), (uint64_t)&add[0] - (uint64_t)GetModuleHandle(NULL));
 

--- a/apex_guest/Client/Client/main.h
+++ b/apex_guest/Client/Client/main.h
@@ -15,3 +15,4 @@ extern float hip_fov;
 extern float hip_smooth;
 extern bool aassist;
 extern float aassist_dist;
+extern int triggerbot_hitbox;

--- a/apex_guest/Client/Client/overlay.cpp
+++ b/apex_guest/Client/Client/overlay.cpp
@@ -192,6 +192,21 @@ void Overlay::RenderMenu()
 			ImGui::Checkbox(XorStr("Triggerbot (LSHIFT)"), &triggerbot);
 			ImGui::SliderFloat(XorStr("Trigger FOV"), &triggerbot_fov, 1.0f, 1000.0f, "%.2f");
 
+			const char* trigger_hitboxes[] = { "NONE", "Head (0)", "Neck (1)", "Upper Chest (2)", "Lower Chest (3)", "Stomach (4)", "Hip (11)", "NEAR3", "NEAR6", "NEAR12", "ALL" };
+			int current_trigger_hitbox = 0;
+			if (triggerbot_hitbox == -1) current_trigger_hitbox = 0;
+			else if (triggerbot_hitbox >= 0 && triggerbot_hitbox <= 4) current_trigger_hitbox = triggerbot_hitbox + 1;
+			else if (triggerbot_hitbox == 11) current_trigger_hitbox = 6;
+			else if (triggerbot_hitbox >= 101 && triggerbot_hitbox <= 104) current_trigger_hitbox = triggerbot_hitbox - 101 + 7;
+
+			if (ImGui::Combo(XorStr("Trigger Hitbox"), &current_trigger_hitbox, trigger_hitboxes, IM_ARRAYSIZE(trigger_hitboxes)))
+			{
+				if (current_trigger_hitbox == 0) triggerbot_hitbox = -1;
+				else if (current_trigger_hitbox >= 1 && current_trigger_hitbox <= 5) triggerbot_hitbox = current_trigger_hitbox - 1;
+				else if (current_trigger_hitbox == 6) triggerbot_hitbox = 11;
+				else if (current_trigger_hitbox >= 7) triggerbot_hitbox = current_trigger_hitbox - 7 + 101;
+			}
+
 			ImGui::Checkbox(XorStr("Aim Assist (RMB)"), &aassist);
 
 			ImGui::EndTabItem();


### PR DESCRIPTION
This change optimizes the triggerbot by introducing a "NONE" hitbox option that uses a static Z-offset from the player's origin, reducing the need for multiple bone position DMA reads. It also adds several multi-bone presets (NEAR3, NEAR6, NEAR12, ALL) to make the triggerbot more responsive by firing when the crosshair is near any of the selected body parts. The implementation includes UI updates, configuration persistence, and performance optimizations in the DMA host loop.

---
*PR created automatically by Jules for task [2718260332357058254](https://jules.google.com/task/2718260332357058254) started by @albatror*